### PR TITLE
Adds use_logging parameter to BatchPoster

### DIFF
--- a/migration_tools/migration_tasks/batch_poster.py
+++ b/migration_tools/migration_tasks/batch_poster.py
@@ -38,8 +38,9 @@ class BatchPoster(MigrationTaskBase):
         self,
         task_config: TaskConfiguration,
         library_config: LibraryConfiguration,
+        use_logging: bool = True
     ):
-        super().__init__(library_config, task_config)
+        super().__init__(library_config, task_config, use_logging)
         self.task_config = task_config
         self.failed_ids = []
         self.first_batch = True


### PR DESCRIPTION
Otherwise causes error when using the `BatchPoster` within Airflow.