### PR TITLE
generate multiple values/objects for data with delimiters. closes #183

### DIFF
--- a/src/folio_migration_tools/library_configuration.py
+++ b/src/folio_migration_tools/library_configuration.py
@@ -47,6 +47,7 @@ class LibraryConfiguration(BaseModel):
             "Should ideally be a github clone of the migration_repo_template"
         )
     )
+    multi_field_delimiter: Optional[str] = "<delimiter>"
     failed_records_threshold: Optional[int] = 5000
     failed_percentage_threshold: Optional[int] = 20
     library_name: str

--- a/src/folio_migration_tools/mapper_base.py
+++ b/src/folio_migration_tools/mapper_base.py
@@ -1,18 +1,17 @@
+import json
 import logging
 import sys
-import json
-import requests
 
-from folio_migration_tools.custom_exceptions import (
-    TransformationProcessError,
-    TransformationRecordFailedError,
-)
-from folioclient import FolioClient
+import requests
 from folio_uuid.folio_namespaces import FOLIONamespaces
+from folioclient import FolioClient
+
+from folio_migration_tools.custom_exceptions import TransformationProcessError
+from folio_migration_tools.custom_exceptions import TransformationRecordFailedError
+from folio_migration_tools.library_configuration import LibraryConfiguration
 from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
     RefDataMapping,
 )
-from folio_migration_tools.library_configuration import LibraryConfiguration
 from folio_migration_tools.migration_report import MigrationReport
 from folio_migration_tools.report_blurbs import Blurbs
 
@@ -289,7 +288,7 @@ class MapperBase:
         legacy_id, folio_object: dict, schema: dict, object_type: FOLIONamespaces
     ):
         cleaned_folio_object = MapperBase.clean_none_props(folio_object)
-        required = schema["required"]
+        required = schema.get("required", [])
         missing = []
         for required_prop in required:
             if required_prop not in cleaned_folio_object:

--- a/tests/test_user_transformer.py
+++ b/tests/test_user_transformer.py
@@ -1,9 +1,11 @@
 import logging
-from unittest.mock import MagicMock, Mock
 import uuid
-from folioclient import FolioClient
-from folio_migration_tools.library_configuration import LibraryConfiguration
+from unittest.mock import MagicMock
+from unittest.mock import Mock
 
+from folioclient import FolioClient
+
+from folio_migration_tools.library_configuration import LibraryConfiguration
 from folio_migration_tools.mapping_file_transformation.user_mapper import UserMapper
 from folio_migration_tools.migration_tasks.user_transformer import UserTransformer
 
@@ -34,6 +36,7 @@ def test_basic():
     }
     mock_library_conf = Mock(spec=LibraryConfiguration)
     mock_task_config = Mock(spec=UserTransformer.TaskConfiguration)
+    mock_task_config.multi_field_delimiter = "<delimiter>"
     mock_folio = Mock(spec=FolioClient)
     mock_folio.okapi_url = "okapi_url"
     mock_folio.folio_get_single_object = MagicMock(
@@ -111,6 +114,7 @@ def test_notes(caplog):
     }
     mock_library_conf = Mock(spec=LibraryConfiguration)
     mock_task_config = Mock(spec=UserTransformer.TaskConfiguration)
+    mock_task_config.multi_field_delimiter = "<delimiter>"
     mock_folio = Mock(spec=FolioClient)
     mock_folio.okapi_url = "okapi_url"
     mock_folio.folio_get_single_object = MagicMock(
@@ -191,6 +195,8 @@ def test_notes_empty_field(caplog):
     }
     mock_library_conf = Mock(spec=LibraryConfiguration)
     mock_task_config = Mock(spec=UserTransformer.TaskConfiguration)
+    mock_task_config.multi_field_delimiter = "<delimiter>"
+
     mock_folio = Mock(spec=FolioClient)
     mock_folio.okapi_url = "okapi_url"
     mock_folio.folio_get_single_object = MagicMock(

--- a/tests/test_user_transformer.py
+++ b/tests/test_user_transformer.py
@@ -114,7 +114,7 @@ def test_notes(caplog):
     }
     mock_library_conf = Mock(spec=LibraryConfiguration)
     mock_task_config = Mock(spec=UserTransformer.TaskConfiguration)
-    mock_task_config.multi_field_delimiter = "<delimiter>"
+    mock_library_conf.multi_field_delimiter = "<delimiter>"
     mock_folio = Mock(spec=FolioClient)
     mock_folio.okapi_url = "okapi_url"
     mock_folio.folio_get_single_object = MagicMock(
@@ -195,7 +195,7 @@ def test_notes_empty_field(caplog):
     }
     mock_library_conf = Mock(spec=LibraryConfiguration)
     mock_task_config = Mock(spec=UserTransformer.TaskConfiguration)
-    mock_task_config.multi_field_delimiter = "<delimiter>"
+    mock_library_conf.multi_field_delimiter = "<delimiter>"
 
     mock_folio = Mock(spec=FolioClient)
     mock_folio.okapi_url = "okapi_url"


### PR DESCRIPTION
See tests. 
For object arrays, like Notes, electronicAccess, fields containing a delimiter will be split into multiple objects.
For string arrays, multiple values will be added.
