### PR TITLE
closes #347 increase test coverage in srcfolio migration toolsmarc rules transformationrules mapper holdingspy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,9 @@ When you make edits to this document, make sure you update the Table of contents
   - [Writing tests](#writing-tests)
   - [Code coverage](#code-coverage)
   - [Running an end-to-end transformation](#running-an-end-to-end-transformation)
-# Writing Issues.
+
+
+# Writing issues
 Writing good issues is key.
 Both for sharing to the larger group of users what is needed or not working, but also for helping the developer working on the issue to reach the Definition Of Done (DoD) and beyond.
 
@@ -43,7 +45,7 @@ For the developer writing the issue, it is good practice to share a screenshot o
 Formulating a DoD is good practice. Take a moment to do this properly.   
 
 
-# Git(hub) workflow
+# Code contribution workflow
 We use [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow)
 In the ideal situation, this is what you do:
 ## 1. Create a branch off of main and name it according to the feature you are working on
@@ -71,6 +73,7 @@ Run
 pipenv run safety check
 ```
 and update any packages with a vulnerability.
+
 ### 3.2. :monocle_face: Check and format your code
 The following command runs Flake8 with plugins on your code. It:
 * Uses black to format the code. The Line-lenght is to be 99 characters
@@ -108,7 +111,7 @@ optional arguments:
 ```
 
 ## 3.5. Create a pull request in GitHub
-## 3.6. :people_holding_hands: Code review.
+## 3.6. :people_holding_hands: Code review
 
 # Create release
 ## Create the release on Github

--- a/tests/test_rules_mapper_holdings.py
+++ b/tests/test_rules_mapper_holdings.py
@@ -1,5 +1,7 @@
 import pymarc
 
+from unittest.mock import Mock
+
 from folio_migration_tools.marc_rules_transformation.holdings_statementsparser import (
     HoldingsStatementsParser,
 )
@@ -29,3 +31,24 @@ def test_get_marc_textual_stmt_correct_order_and_not_deduped():
         all_stmts = [f["statement"] for f in rec["holdingsStatements"]]
         all_94s = [f for f in all_stmts if stmt == f]
         assert len(all_94s) == 2
+
+
+def test_remove_from_id_map():
+    mocked_rules_mapper_holdings = Mock(spec=RulesMapperHoldings)
+    former_ids = ["formerid123"]
+
+    RulesMapperHoldings.remove_from_id_map(mocked_rules_mapper_holdings, former_ids)
+
+    assert "formerid123" not in mocked_rules_mapper_holdings.holdings_id_map
+
+
+def test_set_default_call_number_type_if_empty():
+    mocked_rules_mapper_holdings = Mock(spec=RulesMapperHoldings)
+
+    folio_holding = {"callNumberTypeId": ""}
+
+    RulesMapperHoldings.set_default_call_number_type_if_empty(
+        mocked_rules_mapper_holdings, folio_holding
+    )
+
+    assert folio_holding["callNumberTypeId"]


### PR DESCRIPTION
Apologies for the extra commits in this branch -- they were related to issue 218 and had already been merged in.

The real changes are in tests/test_rules_mapper_holdings.py