### PR TITLE
Refactored BatchPoster to generalize handling record types that do not support batch loading APIs (eg. Authorities and Organizations)

### DIFF
--- a/src/folio_migration_tools/migration_tasks/batch_poster.py
+++ b/src/folio_migration_tools/migration_tasks/batch_poster.py
@@ -179,7 +179,7 @@ class BatchPoster(MigrationTaskBase):
     def post_single_records(self, row: str, num_records: int, failed_recs_file):
         kind = list_objects(self.task_configuration.object_type)
         if kind["is_batch"]:
-            raise Exception("This record type supports batch processing, use post_batch method")
+            raise TypeError("This record type supports batch processing, use post_batch method")
         api_endpoint = kind.get("api_endpoint")
         url = f"{self.folio_client.okapi_url}{api_endpoint}"
         response = self.post_objects(url, row)


### PR DESCRIPTION
A minor tweak in service of handling single-record API types. Refactored to generalize existing handling for authorities to any type that doesn't have a batch API:

- Replaced `post_authorities method` with `post_single_records`
- Added a `"is_batch"` attribute to `list_objects` `"choices"` objects 