### PR TITLE
469 remove extraneous fields from user objects created by usermapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,3 @@ In order to perform migrations according to this process, you need the following
 # Running the scripts
 For information on syntax, what files are needed and produced by the toolkit, refer to the documentation and example files in the [template repository](https://github.com/FOLIO-FSE/migration_repo_template). We are building out the docs section in this repository as well:[Documentation](https://folio-migration-tools.readthedocs.io/en/latest/)
 ¨
-

--- a/src/folio_migration_tools/mapping_file_transformation/user_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/user_mapper.py
@@ -78,10 +78,8 @@ class UserMapper(MappingFileMapperBase):
         folio_user["personal"]["preferredContactTypeId"] = "Email"
         folio_user["active"] = True
         folio_user["requestPreference"] = {
-            "userId": folio_user["id"],
             "holdShelf": True,
             "delivery": False,
-            "metadata": self.folio_client.get_metadata_construct(),
         }
         clean_folio_object = self.validate_required_properties(
             index_or_id, folio_user, self.schema, FOLIONamespaces.users

--- a/src/folio_migration_tools/migration_tasks/user_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/user_transformer.py
@@ -189,6 +189,9 @@ class UserTransformer(MigrationTaskBase):
             else:
                 # No primary address
                 addresses[0]["primaryAddress"] = True
+        # TODO: Consider removing the object metadata construct globally in MappingFileMapperBase
+        if folio_user.get("metadata", {}):
+            del folio_user["metadata"]
 
 
 def print_email_warning():

--- a/tests/test_user_mapper.py
+++ b/tests/test_user_mapper.py
@@ -67,7 +67,6 @@ def test_basic(mocked_folio_client):
     assert folio_user["id"] == "c2a8733b-4fbc-5ef1-ace9-f02e7b3a6f35"
     assert folio_user["personal"]["preferredContactTypeId"] == "Email"
     assert folio_user["active"] is True
-    assert folio_user["requestPreference"]["userId"] == folio_user["id"]
 
 
 def test_basic_fallback(mocked_folio_client):


### PR DESCRIPTION
Small tweaks to the user mapper and user transformer tasks to avoid creating objects or adding fields to the generated user record that can cause problems when reloading users without clearing existing data. Closes #469.