### PR TITLE
509 mapper incorrectly fails record where a non required enum is empty

### DIFF
--- a/src/fetch_default_ref_data.py
+++ b/src/fetch_default_ref_data.py
@@ -87,7 +87,6 @@ def main():
 def get_ref_data_from_github_folder(owner, repo, folder_path: str):
     ret_arr = []
     try:
-
         logging.info("Using GITHB_TOKEN environment variable for Gihub API Access")
         github_headers = {
             "content-type": "application/json",

--- a/src/folio_migration_tools/extradata_writer.py
+++ b/src/folio_migration_tools/extradata_writer.py
@@ -8,7 +8,6 @@ from folio_migration_tools.custom_exceptions import TransformationProcessError
 
 
 class ExtradataWriter:
-
     __instance = None
     __inited = False
 

--- a/src/folio_migration_tools/holdings_helper.py
+++ b/src/folio_migration_tools/holdings_helper.py
@@ -155,7 +155,6 @@ class HoldingsHelper:
 def extend_list(
     prop_name: str, holdings_record: dict, incoming_holdings: dict, accept_dupe_items: bool = False
 ):
-
     temp = holdings_record.get(prop_name, [])
     all_already_in = all(i in temp for i in incoming_holdings.get(prop_name, []))
     for f in incoming_holdings.get(prop_name, []):

--- a/src/folio_migration_tools/mapper_base.py
+++ b/src/folio_migration_tools/mapper_base.py
@@ -21,7 +21,6 @@ from folio_migration_tools.report_blurbs import Blurbs
 
 
 class MapperBase:
-
     legacy_id_template = "Identifier(s) from previous system:"
     bib_id_template = "Bib id: "
 
@@ -167,7 +166,6 @@ class MapperBase:
         folio_property_name="",
         prevent_default=False,
     ):
-
         # Gets mapped value from mapping file, translated to the right FOLIO UUID
         try:
             # Get the values in the fields that will be used for mapping
@@ -362,7 +360,6 @@ class MapperBase:
 
 
 def flatten(my_dict: dict, path=""):
-
     for k, v in iter(my_dict.items()):
         if not path:
             yield k

--- a/src/folio_migration_tools/mapping_file_transformation/holdings_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/holdings_mapper.py
@@ -56,7 +56,6 @@ class HoldingsMapper(MappingFileMapperBase):
             )
 
     def get_prop(self, legacy_item, folio_prop_name, index_or_id):
-
         # Legacy contstruct
         if not self.use_map:
             return legacy_item[folio_prop_name]

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -476,6 +476,7 @@ class MappingFileMapperBase(MapperBase):
                                 self.library_configuration.multi_field_delimiter,
                             )
             i = i + 1
+            
             if temp_object != {} and all(
                 temp_object.get(r) or (isinstance(temp_object.get(r), bool)) for r in required
             ):
@@ -491,8 +492,11 @@ class MappingFileMapperBase(MapperBase):
                     resulting_array.append(temp_object)
 
             elif any(
-                (v for k, v in temp_object.items() if not self.is_uuid(v))
-                and not isinstance(v, bool)
+                (
+                    v
+                    for k, v in temp_object.items()
+                    if not self.is_uuid(v) and not isinstance(v, bool)
+                )
             ):
                 self.migration_report.add(
                     Blurbs.IncompleteSubPropertyRemoved,
@@ -731,7 +735,7 @@ class MappingFileMapperBase(MapperBase):
             )
 
     def is_uuid(self, value):
-        """ Returns True if the value is a UUID, and False if it is not.
+        """Returns True if the value is a UUID, and False if it is not.
 
         Args:
             value (_type_): a value that may or may not be a UUID

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -183,7 +183,6 @@ class MappingFileMapperBase(MapperBase):
         ]
 
     def instantiate_record(self, legacy_object: dict, index_or_id, object_type: FOLIONamespaces):
-
         if self.ignore_legacy_identifier:
             return ({}, str(uuid.uuid4()))
 
@@ -241,7 +240,6 @@ class MappingFileMapperBase(MapperBase):
     def do_map(
         self, legacy_object, index_or_id: str, object_type: FOLIONamespaces
     ) -> tuple[dict, str]:
-
         folio_object, legacy_id = self.instantiate_record(legacy_object, index_or_id, object_type)
         for property_name, property in self.schema["properties"].items():
             try:
@@ -551,7 +549,6 @@ class MappingFileMapperBase(MapperBase):
     ):
         if self.has_basic_property(legacy_object, property_name):  # is there a match in the csv?
             if mapped_prop := self.get_prop(legacy_object, property_name, index_or_id):
-
                 self.validate_enums(
                     mapped_prop,
                     schema_property,

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -19,7 +19,6 @@ from folioclient import FolioClient
 from folio_migration_tools.custom_exceptions import TransformationFieldMappingError
 from folio_migration_tools.custom_exceptions import TransformationProcessError
 from folio_migration_tools.custom_exceptions import TransformationRecordFailedError
-from folio_migration_tools.helper import Helper
 from folio_migration_tools.library_configuration import LibraryConfiguration
 from folio_migration_tools.mapper_base import MapperBase
 from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
@@ -476,7 +475,7 @@ class MappingFileMapperBase(MapperBase):
                                 self.library_configuration.multi_field_delimiter,
                             )
             i = i + 1
-            
+
             if temp_object != {} and all(
                 temp_object.get(r) or (isinstance(temp_object.get(r), bool)) for r in required
             ):

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -490,7 +490,10 @@ class MappingFileMapperBase(MapperBase):
                 else:
                     resulting_array.append(temp_object)
 
-            elif any((v for k, v in temp_object.items() if not self.uuid_check(v))):
+            elif any(
+                (v for k, v in temp_object.items() if not self.is_uuid(v))
+                and not isinstance(v, bool)
+            ):
                 self.migration_report.add(
                     Blurbs.IncompleteSubPropertyRemoved,
                     f"{prop_name}.{sub_prop}",
@@ -727,7 +730,15 @@ class MappingFileMapperBase(MapperBase):
                 mapped_value,
             )
 
-    def uuid_check(self, value):
+    def is_uuid(self, value):
+        """ Returns True if the value is a UUID, and False if it is not.
+
+        Args:
+            value (_type_): a value that may or may not be a UUID
+
+        Returns:
+            bool: True/False
+        """
         try:
             uuid.UUID(str(value))
         except ValueError:

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -19,6 +19,7 @@ from folioclient import FolioClient
 from folio_migration_tools.custom_exceptions import TransformationFieldMappingError
 from folio_migration_tools.custom_exceptions import TransformationProcessError
 from folio_migration_tools.custom_exceptions import TransformationRecordFailedError
+from folio_migration_tools.helper import Helper
 from folio_migration_tools.library_configuration import LibraryConfiguration
 from folio_migration_tools.mapper_base import MapperBase
 from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
@@ -492,6 +493,15 @@ class MappingFileMapperBase(MapperBase):
                     )
                 else:
                     resulting_array.append(temp_object)
+
+            elif any((v for k, v in temp_object.items() if not self.uuid_check(v))):
+                Helper.log_data_issue(
+                    f"{prop_name}",
+                    f"Sub-property {sub_prop} removed as it is missing required fields:"
+                    f"{required}",
+                    temp_object,
+                )
+
         if any(resulting_array):
             set_deep2(folio_object, prop_name, resulting_array)
 
@@ -716,6 +726,13 @@ class MappingFileMapperBase(MapperBase):
                 f"Allowed values are: {mapped_schema_property['enum']}",
                 mapped_value,
             )
+
+    def uuid_check(self, value):
+        try:
+            uuid.UUID(str(value))
+        except ValueError:
+            return False
+        return True
 
 
 def skip_property(property_name, property):

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -476,12 +476,8 @@ class MappingFileMapperBase(MapperBase):
                                 self.library_configuration.multi_field_delimiter,
                             )
             i = i + 1
-            if (
-                temp_object != {}
-                and all(
-                    (v or (isinstance(v, bool)) for k, v in temp_object.items() if k in required)
-                )
-                and all(r in temp_object for r in required)
+            if temp_object != {} and all(
+                temp_object.get(r) or (isinstance(temp_object.get(r), bool)) for r in required
             ):
                 if any(multi_field_props):
                     resulting_array.extend(
@@ -495,12 +491,16 @@ class MappingFileMapperBase(MapperBase):
                     resulting_array.append(temp_object)
 
             elif any((v for k, v in temp_object.items() if not self.uuid_check(v))):
-                Helper.log_data_issue(
-                    f"{prop_name}",
-                    f"Sub-property {sub_prop} removed as it is missing required fields:"
-                    f"{required}",
-                    temp_object,
+                self.migration_report.add(
+                    Blurbs.IncompleteSubPropertyRemoved,
+                    f"{prop_name}.{sub_prop}",
                 )
+                # Helper.log_data_issue(
+                #     f"{prop_name}",
+                #     f"Sub-property {sub_prop} removed as it is missing required fields:"
+                #     f"{required}",
+                #     temp_object,
+                # )
 
         if any(resulting_array):
             set_deep2(folio_object, prop_name, resulting_array)

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -444,11 +444,11 @@ class MappingFileMapperBase(MapperBase):
                             and self.library_configuration.multi_field_delimiter in res
                         ):
                             multi_field_props.append(sub_prop_name)
-                        
-                        self.validate_enums(res, sub_prop, sub_prop_name, index_or_id, required)
 
-                        if res:
+                        self.validate_enums(res, sub_prop, sub_prop_name, index_or_id, required)
+                        if res or isinstance(res, bool):
                             temp_object[sub_prop_name] = res
+
                     elif (
                         sub_prop_name in sub_properties
                         and sub_properties[sub_prop_name].get("type", "") == "array"
@@ -477,8 +477,12 @@ class MappingFileMapperBase(MapperBase):
                                 self.library_configuration.multi_field_delimiter,
                             )
             i = i + 1
-            if temp_object != {} and all(
-                (v or (isinstance(v, bool)) for k, v in temp_object.items() if k in required)
+            if (
+                temp_object != {}
+                and all(
+                    (v or (isinstance(v, bool)) for k, v in temp_object.items() if k in required)
+                )
+                and all(r in temp_object for r in required)
             ):
                 if any(multi_field_props):
                     resulting_array.extend(
@@ -693,7 +697,12 @@ class MappingFileMapperBase(MapperBase):
         return self.ref_data_dicts.get(dict_key, {}).get(key_value.lower().strip(), ())
 
     def validate_enums(
-        self, mapped_value, mapped_schema_property, mapped_schema_property_name, index_or_id, required
+        self,
+        mapped_value,
+        mapped_schema_property,
+        mapped_schema_property_name,
+        index_or_id,
+        required,
     ):
         if (
             "enum" in mapped_schema_property

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapping_base_impl.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapping_base_impl.py
@@ -18,7 +18,6 @@ class MappingFileMappingBaseImpl(MappingFileMapperBase):
         object_type: FOLIONamespaces,
         ignore_legacy_identifier: bool = False,
     ):
-
         super().__init__(
             folio_client,
             schema,

--- a/src/folio_migration_tools/mapping_file_transformation/notes_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/notes_mapper.py
@@ -47,7 +47,6 @@ class NotesMapper(MappingFileMappingBaseImpl):
 
     def map_notes(self, legacy_object, legacy_id, object_uuid: str, record_type: FOLIONamespaces):
         if any(self.noteprops["data"]):
-
             for note in self.do_map(legacy_object, legacy_id, FOLIONamespaces.note)[0].get(
                 "notes", []
             ):

--- a/src/folio_migration_tools/mapping_file_transformation/organization_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/organization_mapper.py
@@ -30,7 +30,6 @@ class OrganizationMapper(MappingFileMapperBase):
         email_categories_map,
         phone_categories_map,
     ):
-
         # Build composite organization schema
         organization_schema = OrganizationMapper.get_latest_acq_schemas_from_github(
             "folio-org", "mod-organizations-storage", "mod-orgs", "organization"
@@ -189,7 +188,6 @@ class OrganizationMapper(MappingFileMapperBase):
             _type_: _description_
         """
         try:
-
             # Authenticate when calling GitHub, using an API key stored in .env
             github_headers = {
                 "content-type": "application/json",
@@ -304,9 +302,7 @@ class OrganizationMapper(MappingFileMapperBase):
         supported_types = ["string", "boolean", "number", "integer", "text", "object", "array"]
 
         try:
-
             for property_name_level1, property_level1 in object_schema["properties"].items():
-
                 # For now, treat references to UUIDs like strings
                 # It's not great practice, but it's the way FOLIO mostly handles it
                 if "../../common/schemas/uuid.json" in property_level1.get("$ref", ""):
@@ -342,13 +338,11 @@ class OrganizationMapper(MappingFileMapperBase):
                     or "../" in property_level1.get("$ref", "")
                     or "../" in property_level1.get("items", {}).get("$ref", "")
                 ):
-
                     logging.info(f"Property not yet supported: {property_name_level1}")
                     property_level1["type"] = "Deprecated"
 
                 # Handle object properties
                 elif property_level1.get("type") == "object" and property_level1.get("$ref"):
-
                     logging.info("Fecthing referenced schema for object %s", property_name_level1)
 
                     ref_object = property_level1["$ref"]
@@ -362,7 +356,6 @@ class OrganizationMapper(MappingFileMapperBase):
                 elif property_level1.get("type") == "array" and property_level1.get("items").get(
                     "$ref"
                 ):
-
                     ref_object = property_level1["items"]["$ref"]
                     schema_url = f"{submodule_path}/{ref_object}"
 

--- a/src/folio_migration_tools/marc_rules_transformation/conditions.py
+++ b/src/folio_migration_tools/marc_rules_transformation/conditions.py
@@ -132,7 +132,6 @@ class Conditions:
         logging.info("%s\tholdings types", len(self.holdings_types))
 
     def setup_reference_data_for_all(self):
-
         logging.info(f"{len(self.folio.class_types)}\tclass_types")
         logging.info(
             f"{len(self.folio.electronic_access_relationships)}\telectronic_access_relationships"
@@ -609,7 +608,6 @@ class Conditions:
     def condition_set_permanent_location_id(
         self, legacy_id, value, parameter, marc_field: field.Field
     ):
-
         if "legacy_locations" not in self.ref_data_dicts:
             try:
                 d = {lm["legacy_code"]: lm["folio_code"] for lm in self.mapper.location_map}

--- a/src/folio_migration_tools/marc_rules_transformation/hrid_handler.py
+++ b/src/folio_migration_tools/marc_rules_transformation/hrid_handler.py
@@ -148,7 +148,6 @@ class HRIDHandler:
     def store_hrid_settings(self):
         logging.info("Setting HRID counter to current")
         try:
-
             if self.hrids_not_updated():
                 logging.info("NOT POSTing HRID settings, since did not change.")
                 return

--- a/src/folio_migration_tools/marc_rules_transformation/rules_mapper_base.py
+++ b/src/folio_migration_tools/marc_rules_transformation/rules_mapper_base.py
@@ -429,7 +429,6 @@ class RulesMapperBase(MapperBase):
             target_field.get("type", "") == "array"
             and target_field.get("items", {}).get("type", "") == "string"
         ):
-
             if target_string not in rec:
                 rec[target_string] = value
             else:

--- a/src/folio_migration_tools/marc_rules_transformation/rules_mapper_holdings.py
+++ b/src/folio_migration_tools/marc_rules_transformation/rules_mapper_holdings.py
@@ -325,7 +325,6 @@ class RulesMapperHoldings(RulesMapperBase):
                 f"Already set to {folio_holding.get('holdingsTypeId')}. LDR[06] was {ldr06}",
             )
         else:
-
             holdings_type = self.conditions.holdings_type_map.get(ldr06, "")
             if t := self.conditions.get_ref_data_tuple_by_name(
                 self.conditions.holdings_types, "hold_types", holdings_type

--- a/src/folio_migration_tools/migration_tasks/bibs_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/bibs_transformer.py
@@ -56,7 +56,6 @@ class BibsTransformer(MigrationTaskBase):
         library_config: LibraryConfiguration,
         use_logging: bool = True,
     ):
-
         super().__init__(library_config, task_config, use_logging)
         self.processor: MarcFileProcessor
         self.check_source_files(

--- a/src/folio_migration_tools/migration_tasks/migration_task_base.py
+++ b/src/folio_migration_tools/migration_tasks/migration_task_base.py
@@ -38,7 +38,6 @@ class MigrationTaskBase:
         task_configuration,
         use_logging: bool = True,
     ):
-
         logging.info("MigrationTaskBase init")
         self.start_datetime = datetime.now(timezone.utc)
         self.task_configuration = task_configuration

--- a/src/folio_migration_tools/migration_tasks/organization_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/organization_transformer.py
@@ -222,7 +222,6 @@ class OrganizationTransformer(MigrationTaskBase):
         logging.info("All done!")
 
     def clean_org(self, folio_rec):
-
         self.clean_org_type_pre_morning_glory(folio_rec, self.library_configuration.folio_release)
         self.clean_addresses(folio_rec)
 

--- a/src/folio_migration_tools/migration_tasks/requests_migrator.py
+++ b/src/folio_migration_tools/migration_tasks/requests_migrator.py
@@ -144,7 +144,6 @@ class RequestsMigrator(MigrationTaskBase):
             self.valid_legacy_requests[self.task_configuration.starting_row - 1 :],
             start=1,
         ):
-
             t0_migration = time.time()
             try:
                 res, legacy_request = self.prepare_legacy_request(legacy_request)

--- a/src/folio_migration_tools/migration_tasks/reserves_migrator.py
+++ b/src/folio_migration_tools/migration_tasks/reserves_migrator.py
@@ -76,7 +76,6 @@ class ReservesMigrator(MigrationTaskBase):
                 logging.info(f"{timings(self.t0, t0_migration, num_reserves)} {num_reserves}")
 
     def post_single_reserve(self, legacy_reserve: LegacyReserve):
-
         try:
             path = f"/coursereserves/courselistings/{legacy_reserve.course_listing_id}/reserves"
             if self.folio_put_post(path, legacy_reserve.to_dict(), "POST", "Posted reserves"):

--- a/src/folio_migration_tools/report_blurbs.py
+++ b/src/folio_migration_tools/report_blurbs.py
@@ -10,6 +10,7 @@ class ReportSection(Enum):
 
 class Blurbs:
     AuthoritySources = ("Authorization sources and related information", "")
+    IncompleteSubPropertyRemoved = ("Sub-property removed due to missing required fields", "")
     FieldMappingDetails = ("Mapping details", "")
     CatalogingAgency = ("Cataloging sources", "")
     Trivia = ("Trivia", "")

--- a/tests/test_batch_poster.py
+++ b/tests/test_batch_poster.py
@@ -9,7 +9,6 @@ def test_get_object_type():
 
 
 def test_get_unsafe_and_safe_endpoints():
-
     assert (
         batch_poster.get_api_info("Instances", False)["api_endpoint"]
         == "/instance-storage/batch/synchronous-unsafe"

--- a/tests/test_courses_mapper.py
+++ b/tests/test_courses_mapper.py
@@ -191,6 +191,12 @@ basic_course_map = {
             "description": "",
         },
         {
+            "folio_field": "instructors[0].courseListingId",
+            "legacy_field": "RECORD #(COURSE)",
+            "value": "",
+            "description": "",
+        },
+        {
             "folio_field": "notes[0].domain",
             "legacy_field": "Not mapped",
             "value": "courses",

--- a/tests/test_holdings_csv_transformer.py
+++ b/tests/test_holdings_csv_transformer.py
@@ -41,7 +41,6 @@ def test_generate_boundwith_part(caplog):
 
 
 def test_merge_holding_in_first_boundwith(caplog):
-
     mock_folio = mocked_classes.mocked_folio_client()
 
     mock_mapper = Mock(spec=HoldingsMapper)
@@ -63,7 +62,6 @@ def test_merge_holding_in_first_boundwith(caplog):
 
 
 def test_merge_holding_in_second_boundwith_to_merge(caplog):
-
     mock_folio = mocked_classes.mocked_folio_client()
 
     mock_mapper = Mock(spec=HoldingsMapper)
@@ -95,7 +93,6 @@ def test_merge_holding_in_second_boundwith_to_merge(caplog):
 
 
 def test_merge_holding_in_second_boundwith_to_not_merge(caplog):
-
     mock_folio = mocked_classes.mocked_folio_client()
 
     mock_mapper = Mock(spec=HoldingsMapper)

--- a/tests/test_mapper_base.py
+++ b/tests/test_mapper_base.py
@@ -8,7 +8,6 @@ from folio_migration_tools.mapper_base import MapperBase
 
 
 def test_validate_required_properties():
-
     schema = {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "description": "",

--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -2219,6 +2219,7 @@ def test_map_enums_empty_not_required(mocked_folio_client):
     folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
     assert "status" not in folio_rec
 
+
 def test_map_enums_invalid_required(mocked_folio_client):
     schema = {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -2377,6 +2378,7 @@ def test_map_enums_empty_not_required_deeper_level(mocked_folio_client):
     mapper = MyTestableFileMapper(schema, the_map, mocked_folio_client)
     folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
     assert "deliveryMethod" not in folio_rec["interfaces"][0]
+
 
 def test_map_enums_invalid_not_required_deeper_level(mocked_folio_client):
     schema = {

--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -122,7 +122,7 @@ def test_validate_required_properties_sub_pro_missing_uri(mocked_folio_client):
             {
                 "folio_field": "electronicAccess[0].relationshipId",
                 "legacy_field": "",
-                "value": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+                "value": "23d1669c-a32d-5bd0-b232-ac40181a5c7e",
                 "description": "",
             },
             {
@@ -134,7 +134,7 @@ def test_validate_required_properties_sub_pro_missing_uri(mocked_folio_client):
             {
                 "folio_field": "electronicAccess[1].relationshipId",
                 "legacy_field": "",
-                "value": "f5d0068e-000-458e-8a81-b85e7b9a14aa",
+                "value": "23d1669c-a32d-5bd0-b232-ac40181a5c7e",
                 "description": "",
             },
             {
@@ -773,6 +773,125 @@ def test_validate_required_properties_item_notes_split_on_delimiter_notes(mocked
     assert folio_rec["notes"][1]["note"] == "my second note"
     assert folio_rec["notes"][1]["staffOnly"] == True
     assert folio_rec["notes"][1]["itemNoteTypeId"] == "A UUID"
+
+
+def test_validate_remove_and_report_incomplete_object_property(mocked_folio_client):
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "description": "The record of an organization",
+        "type": "object",
+        "properties": {
+            "id": {
+                "description": "The unique UUID for this organization",
+                "$ref": "../../common/schemas/uuid.json",
+                "type": "string",
+            },
+            "status": {
+                "description": "The status of this organization",
+                "type": "string",
+                "enum": ["Active", "Inactive", "Pending"],
+            },
+            "interfaces": {
+                "id": "interfaces",
+                "description": "The list of interfaces assigned to this organization",
+                "type": "array",
+                "items": {
+                    "$schema": "http://json-schema.org/draft-04/schema#",
+                    "description": "An interface record",
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "description": "The unique id of this interface",
+                            "$ref": "../../common/schemas/uuid.json",
+                            "type": "string",
+                        },
+                        "uri": {
+                            "description": "The URI this interface",
+                            "type": "string",
+                        },
+                        "name": {"description": "The name of this interface", "type": "string"},
+                    },
+                    "required": ["name"],
+                    "additionalProperties": True,
+                },
+            },
+        },
+        "additionalProperties": False,
+        "required": ["status"],
+    }
+
+    record1 = {
+        "id": "id1",
+        "status": "Active",
+        "int_name": "",
+        "int_uri": "this has a uri but no name",
+        "int_nameB": "A name",
+        "int_uriB": "A uri",
+    }
+
+    record2 = {
+        "id": "id2",
+        "status": "Active",
+        "int_name": "This has a name but no uri",
+        "int_uri": "",
+    }
+
+    record3 = {
+        "id": "id3",
+        "status": "Active",
+        "int_name": "",
+        "int_uri": "eb1e8cd4-4bb6-51b0-a2a7-51159d552e13",
+    }
+    the_map = {
+        "data": [
+            {
+                "folio_field": "legacyIdentifier",
+                "legacy_field": "id",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "status",
+                "legacy_field": "status",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "interfaces[0].uri",
+                "legacy_field": "int_uri",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "interfaces[0].name",
+                "legacy_field": "int_name",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "interfaces[1].uri",
+                "legacy_field": "int_uriB",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "interfaces[1].name",
+                "legacy_field": "int_nameB",
+                "value": "",
+                "description": "",
+            },
+        ]
+    }
+    mapper = MyTestableFileMapper(schema, the_map, mocked_folio_client)
+    folio_rec, folio_id = mapper.do_map(record1, record1["id"], FOLIONamespaces.organizations)
+    assert len(folio_rec["interfaces"]) == 1
+
+    folio_rec, folio_id = mapper.do_map(record2, record2["id"], FOLIONamespaces.organizations)
+    assert "name" in folio_rec["interfaces"][0]
+    assert "uri" not in folio_rec["interfaces"][0]
+
+    folio_rec, folio_id = mapper.do_map(record3, record3["id"], FOLIONamespaces.organizations)
+    assert "interfaces" not in folio_rec
 
 
 def test_multiple_repeated_split_on_delimiter_electronic_access(mocked_folio_client):

--- a/tests/test_organization_mapper.py
+++ b/tests/test_organization_mapper.py
@@ -114,7 +114,6 @@ def test_organization_mapping(mapper):
     assert organization["code"] == "v1"
     assert organization["description"] == "Good stuff!"
     assert organization["status"] == "Active"
-    assert organization["accounts"][0]["accountNo"] == "aha112233"
 
 
 def test_single_org_type_refdata_mapping(mapper):

--- a/tests/test_organization_mapper.py
+++ b/tests/test_organization_mapper.py
@@ -117,7 +117,6 @@ def test_organization_mapping(mapper):
 
 
 def test_single_org_type_refdata_mapping(mapper):
-
     data["vendor_code"] = "v2"
     organization, idx = mapper.do_map(data, data["vendor_code"], FOLIONamespaces.organizations)
 
@@ -126,7 +125,6 @@ def test_single_org_type_refdata_mapping(mapper):
 
 
 def test_single_category_refdata_mapping(mapper):
-
     data["vendor_code"] = "v3"
     organization, idx = mapper.do_map(data, data["vendor_code"], FOLIONamespaces.organizations)
 

--- a/tests/test_organization_transformer.py
+++ b/tests/test_organization_transformer.py
@@ -55,7 +55,6 @@ def test_remove_organization_types_pre_morning_glory():
 
 
 def test_create_and_link_contacts():
-
     mocked_organization_transformer = Mock(spec=OrganizationTransformer)
     mocked_organization_transformer.contacts_cache = {}
     mocked_organization_transformer.extradata_writer = ExtradataWriter(Path(""))

--- a/tests/test_rules_mapper_bibs_no_folio.py
+++ b/tests/test_rules_mapper_bibs_no_folio.py
@@ -92,7 +92,6 @@ def test_get_folio_id_by_code_except(mapper, caplog):
 
 
 def test_create_entity_empty_props(mapper: BibsRulesMapper):
-
     entity_mappings = [
         {
             "target": "contributors.authorityId",


### PR DESCRIPTION
# News in this PR

## Enum validation
https://github.com/FOLIO-FSE/folio_migration_tools/issues/509

- There is one single error message for invalid enum values:
```
            raise TransformationRecordFailedError(
                index_or_id,
                f"Forbidden value for enum property {mapped_schema_property_name}."
                f"Allowed values are: {mapped_schema_property['enum']}",
                mapped_value,
            )
```

- If a property is an enum and required, and the value is not "" and not in the list of allowed enum values -- raise TransformationRecordFailedError.
- If a property is an enum and not required, and the value is not "" and not in the list of allowed enum values  -- raise TransformationRecordFailedError.
- If a property is an enum and required, and the value is "" -- raise TransformationRecordFailedError.
- If a property is an enum and not required, and the value is "" -- silently remove the property.

## Remove object properties which do not contain all required fields, and add report to data issues log
https://github.com/FOLIO-FSE/folio_migration_tools/issues/464

- If an object property does not contain all required fields, but contains at least one field which is not a bool or a UUID -- remove property and report to data issues log.

I am unsure about this one -- on the one hand I think we do want to report on parts of a record that failed to be brought over, as it may have contained other important values and be a candidate for data cleanup. At the same time, I wonder if it will be too hard to distinguish these from once where the "other values" are hardcoded ones. Exempting bools and UUIDs from this was an attempt in that direction.

If name is required, you might want a warning that this one was not migrated:

```
name: 
uri: www.google.com
type: admin
```
whereas this one should just silently fail:
```
name: 
uri: 
type: admin
```
