### PR TITLE
569 improve performance for itemstransformer by calling superget prop only when needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ sphinx = "^5.3.0"
 sphinx-autodoc-typehints = "^1.19.4"
 myst-parser = "^0.18.1"
 pandas = "^1.5.3"
+types-requests = "^2.28.11.17"
+types-python-dateutil = "^2.8.19.11"
 
 [tool.poetry.extras]
 docs = ["m2r", "sphinx", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "toml"]

--- a/src/folio_migration_tools/mapping_file_transformation/holdings_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/holdings_mapper.py
@@ -56,16 +56,16 @@ class HoldingsMapper(MappingFileMapperBase):
             )
 
     def get_prop(self, legacy_item, folio_prop_name, index_or_id):
-        mapped_value = super().get_prop(legacy_item, folio_prop_name, index_or_id)
-
         if folio_prop_name == "permanentLocationId":
             return self.get_location_id(legacy_item, index_or_id, folio_prop_name)
-        elif folio_prop_name == "callNumber":
-            return self.get_call_number(mapped_value)
         elif folio_prop_name == "callNumberTypeId":
             return self.get_call_number_type_id(legacy_item, folio_prop_name, index_or_id)
         elif folio_prop_name.startswith("statisticalCodeIds"):
             return self.get_statistical_code(legacy_item, folio_prop_name, index_or_id)
+
+        mapped_value = super().get_prop(legacy_item, folio_prop_name, index_or_id)
+        if folio_prop_name == "callNumber":
+            return self.get_call_number(mapped_value)
         elif folio_prop_name == "instanceId":
             return self.get_instance_ids(mapped_value, index_or_id)
         elif mapped_value:

--- a/src/folio_migration_tools/marc_rules_transformation/rules_mapper_base.py
+++ b/src/folio_migration_tools/marc_rules_transformation/rules_mapper_base.py
@@ -513,8 +513,8 @@ class RulesMapperBase(MapperBase):
             for temp_field in self.grouped(marc_field):
                 entity = self.create_entity(entity_mapping, temp_field, e_parent, legacy_ids)
                 if entity and (
-                    (type(entity) is dict and all(entity.values()))
-                    or (type(entity) is list and all(entity))
+                    (isinstance(entity, dict) and all(entity.values()))
+                    or (isinstance(entity, list) and all(entity))
                 ):
                     self.add_entity_to_record(entity, e_parent, folio_record, self.schema)
         else:

--- a/tests/test_rules_mapper_base.py
+++ b/tests/test_rules_mapper_base.py
@@ -153,7 +153,7 @@ def test_grouped():
         f020s = record1.get_fields("020")
         grouped = RulesMapperBase.grouped(f020s[1])
         for tf in grouped:
-            assert type(tf) is Field
+            assert isinstance(tf, Field)
             assert tf.tag == "020"
             assert tf.subfields in [
                 ["a", "0870990004 (v. 1)", "c", "20sek"],

--- a/tests/test_rules_mapper_bibs.py
+++ b/tests/test_rules_mapper_bibs.py
@@ -474,7 +474,7 @@ def test_should_add_notes_500_510_to_notes_list(mapper):
     so = [note["staffOnly"] for note in record[0]["notes"]]
     print(so)
     for s in so:
-        assert type(s) is bool
+        assert isinstance(s, bool)
     assert '"Embedded application development for home and industry."--Cover' in notes
 
     assert (


### PR DESCRIPTION
Re-worked `item_mapper.get_prop()` to avoid unneeded calls to it's super(), replaced remaining `type() is` statements with `isinstance()` statements and updated tests to match. Also added some additional dev dependencies for mypy types while I was in there.