### PR TITLE
Removing hrid from folio_holdings if create_source_records=False

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "folio_migration_tools"
-version = "1.7.9"
+version = "1.7.10"
 description =  "A tool allowing you to migrate data from legacy ILS:s (Library systems) into FOLIO LSP"
 authors = ["Theodor Tolstoy <github.teddes@tolstoy.se>", "Lisa Sjögren", "Brooks Travis"]
 license = "MIT"

--- a/src/folio_migration_tools/marc_rules_transformation/rules_mapper_holdings.py
+++ b/src/folio_migration_tools/marc_rules_transformation/rules_mapper_holdings.py
@@ -253,9 +253,12 @@ class RulesMapperHoldings(RulesMapperBase):
         self.pick_first_location_if_many(folio_holding, legacy_ids)
         self.parse_coded_holdings_statements(marc_record, folio_holding, legacy_ids)
         HoldingsHelper.handle_notes(folio_holding)
-        self.hrid_handler.handle_hrid(
-            FOLIONamespaces.holdings, folio_holding, marc_record, legacy_ids
-        )
+        if self.task_configuration.create_source_records:
+            self.hrid_handler.handle_hrid(
+                FOLIONamespaces.holdings, folio_holding, marc_record, legacy_ids
+            )
+        else:
+            del folio_holding["hrid"]
         if not folio_holding.get("instanceId", ""):
             raise TransformationRecordFailedError(
                 "".join(folio_holding.get("formerIds", [])),


### PR DESCRIPTION
@branchedelac @fontanka16 Please take a look at this. As I've already merged the backwards-incompatible changes to the library configurations, I can go ahead and merge this to main and then use the branch to create a new 1.7.10 release.