### PR TITLE
620 error when transforming users with addresses close #620 #504

### DIFF
--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -364,7 +364,8 @@ class MappingFileMapperBase(MapperBase):
         value = legacy_object.get(mapping_file_entry["legacy_field"], "")
 
         if value and mapping_file_entry.get("rules", {}).get("replaceValues", {}):
-            if replaced_val := mapping_file_entry["rules"]["replaceValues"].get(value, ""):
+            replaced_val = mapping_file_entry["rules"]["replaceValues"].get(value, "")
+            if replaced_val or isinstance(replaced_val, bool):
                 migration_report.add(
                     Blurbs.FieldMappingDetails,
                     (

--- a/src/folio_migration_tools/migration_tasks/user_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/user_transformer.py
@@ -181,34 +181,34 @@ class UserTransformer(MigrationTaskBase):
 
     @staticmethod
     def clean_user(folio_user, index_or_id):
+        # TODO: Consider removing the object metadata construct globally in MappingFileMapperBase
+        if folio_user.get("metadata", {}):
+            del folio_user["metadata"]
+
+        # Make sure the user has exactly one primary address
         if addresses := folio_user.get("personal", {}).get("addresses", []):
-            primary_not_set = [
-                a for a in addresses if not isinstance(a.get("primaryAddress"), bool)
-            ]
-            primary_is_true = [a for a in primary_not_set if a["primaryAddress"] is True]
+            primary_true = []
+            for address in addresses:
+                if "primaryAddress" not in address:
+                    address["primaryAddress"] = False
+                elif (
+                    isinstance(address["primaryAddress"], bool)
+                    and address["primaryAddress"] is True
+                ):
+                    primary_true.append(address)
 
-            if len(primary_not_set) != 0 and len(primary_is_true) != 1:
-                for a in primary_not_set:
-                    a["primaryAddress"] = False
-
-                if primaries := [a for a in addresses if a["primaryAddress"] is True]:
-                    for primary in primaries[1:]:
-                        primary["primaryAddress"] = False
-                else:
-                    # No primary address
-                    addresses[0]["primaryAddress"] = True
-
+            if len(primary_true) < 1:
+                addresses[0]["primaryAddress"] = True
+            elif len(primary_true) > 1:
                 logging.log(
                     26,
                     "DATA ISSUE\t%s\t%s\t%s",
                     index_or_id,
-                    "Too many/too few primary addresses for user: ",
-                    addresses,
+                    "Too many addresses mapped as primary. Setting first one to primary.",
+                    primary_true,
                 )
-
-        # TODO: Consider removing the object metadata construct globally in MappingFileMapperBase
-        if folio_user.get("metadata", {}):
-            del folio_user["metadata"]
+                for pt in primary_true[1:]:
+                    pt["primaryAddress"] = False
 
 
 def print_email_warning():

--- a/tests/test_user_mapper.py
+++ b/tests/test_user_mapper.py
@@ -1210,6 +1210,96 @@ def test_boolean_values_static_value_false(mocked_folio_client):
     assert folio_user["personal"]["addresses"][0]["primaryAddress"] is False
 
 
+def test_boolean_values_mapped_value(mocked_folio_client):
+    user_map = {
+        "data": [
+            {
+                "folio_field": "username",
+                "legacy_field": "user_name",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "externalSystemId",
+                "legacy_field": "ext_id",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "personal.addresses[0].addressLine1",
+                "legacy_field": "HOMEADDRESS1",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "personal.addresses[0].primaryAddress",
+                "legacy_field": "primary_yes_no",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "legacyIdentifier",
+                "legacy_field": "id",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "personal.lastName",
+                "legacy_field": "",
+                "value": "Last name",
+                "description": "",
+            },
+        ]
+    }
+
+    legacy_user_records = [
+        {
+            "ext_id": "externalid_1",
+            "user_name": "user_name_1",
+            "HOMEADDRESS1": "Line 1",
+            "HOMEADDRESS2": "Line 2",
+            "HOMEZIP": "12345",
+            "HOMESTATE": "Sjuhärad",
+            "HOMECITY": "Fritsla",
+            "id": "test_boolean_values_mapped_value_1",
+            "primary_yes_no": True,
+        },
+        {
+            "ext_id": "externalid_2",
+            "user_name": "user_name_2",
+            "HOMEADDRESS1": "Line 1",
+            "HOMEADDRESS2": "Line 2",
+            "HOMEZIP": "12345",
+            "HOMESTATE": "Sjuhärad",
+            "HOMECITY": "Fritsla",
+            "id": "test_boolean_values_mapped_value_2",
+            "primary_yes_no": False,
+        },
+    ]
+
+    mock_library_conf = Mock(spec=LibraryConfiguration)
+    mock_task_config = Mock(spec=UserTransformer.TaskConfiguration)
+    mock_library_conf.multi_field_delimiter = "<delimiter>"
+    mock_folio = mocked_folio_client
+    user_mapper = UserMapper(mock_folio, mock_task_config, mock_library_conf, user_map, None, None)
+
+    folio_user, index_or_id = user_mapper.do_map(
+        legacy_user_records[0], legacy_user_records[0]["id"], FOLIONamespaces.users
+    )
+    assert (
+        isinstance(folio_user["personal"]["addresses"][0]["primaryAddress"], bool)
+        and folio_user["personal"]["addresses"][0]["primaryAddress"] is True
+    )
+
+    folio_user, index_or_id = user_mapper.do_map(
+        legacy_user_records[1], legacy_user_records[1]["id"], FOLIONamespaces.users
+    )
+    assert (
+        isinstance(folio_user["personal"]["addresses"][0]["primaryAddress"], bool)
+        and folio_user["personal"]["addresses"][0]["primaryAddress"] is False
+    )
+
+
 def test_json_load_s_booleans(mocked_folio_client):
     json_str = '{"a": true, "b": "true", "c": false, "d": "false", "e": "True", "f": "False"}'
     my_json = json.loads(json_str)

--- a/tests/test_user_transformer.py
+++ b/tests/test_user_transformer.py
@@ -36,3 +36,15 @@ def test_clean_user_all_true():
     }
     UserTransformer.clean_user(folio_user, "id")
     assert any(a["primaryAddress"] is not True for a in folio_user["personal"]["addresses"])
+
+def test_clean_user_no_primary_info():
+    folio_user = {
+        "personal": {
+            "addresses": [
+                {"id": "some id"},
+                {"id": "some other id"},
+            ]
+        }
+    }
+    UserTransformer.clean_user(folio_user, "id")
+    assert any(a["primaryAddress"] is not True for a in folio_user["personal"]["addresses"])

--- a/tests/test_user_transformer.py
+++ b/tests/test_user_transformer.py
@@ -12,17 +12,29 @@ def test_get_object_type():
     assert UserTransformer.get_object_type() == FOLIONamespaces.users
 
 
-def test_clean_user():
+def test_clean_user_remove_metadata():
+    folio_user = {"name": "My Name", "metadata": "hm"}
+    UserTransformer.clean_user(folio_user, "id")
+    assert "metadata" not in folio_user
+
+
+def test_clean_user_all_false():
     folio_user = {
         "personal": {
             "addresses": [
                 {"id": "some id", "primaryAddress": False},
                 {"id": "some other id", "primaryAddress": False},
-            ]
+            ],
+            "metadata": "hm",
         }
     }
     UserTransformer.clean_user(folio_user, "id")
-    assert any(a["primaryAddress"] for a in folio_user["personal"]["addresses"])
+    primary_true = [
+        a
+        for a in folio_user["personal"]["addresses"]
+        if isinstance(a["primaryAddress"], bool) and a["primaryAddress"] is True
+    ]
+    assert len(primary_true) == 1
 
 
 def test_clean_user_all_true():
@@ -35,7 +47,13 @@ def test_clean_user_all_true():
         }
     }
     UserTransformer.clean_user(folio_user, "id")
-    assert any(a["primaryAddress"] is not True for a in folio_user["personal"]["addresses"])
+    primary_true = [
+        a
+        for a in folio_user["personal"]["addresses"]
+        if isinstance(a["primaryAddress"], bool) and a["primaryAddress"] is True
+    ]
+    assert len(primary_true) == 1
+
 
 def test_clean_user_no_primary_info():
     folio_user = {
@@ -47,4 +65,9 @@ def test_clean_user_no_primary_info():
         }
     }
     UserTransformer.clean_user(folio_user, "id")
-    assert any(a["primaryAddress"] is not True for a in folio_user["personal"]["addresses"])
+    primary_true = [
+        a
+        for a in folio_user["personal"]["addresses"]
+        if isinstance(a["primaryAddress"], bool) and a["primaryAddress"] is True
+    ]
+    assert len(primary_true) == 1


### PR DESCRIPTION
**Fixes**
- Users: instead of crashing when an address does not have the isPrimary property, makes sure that all addresses have the isPrimary property and that foe exactly one address per user isPrimary == True, the rest False. #620
- Generic mapping: make replaceValues performs correct replacement when the value to replace _with_ is boolean False #504
- Generic mapping: alight reorganization of tests related to booleans #504

I think we can close #504 as the tests in mapping_file_mapper_base should cover all mappers using ().get_prop, which at this point should be all mappers. If we discover that something specific doesn't work we can add a test for that.