### PR TITLE
542 make mapping file mapper base split value by subfield delimiter before applying replacevalues rule close #542

### DIFF
--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -1954,6 +1954,55 @@ def test_map_string_array_second_level_split_values(mocked_folio_client: FolioCl
     folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
     assert folio_rec["firstLevel"]["stringArray"] == ["my note 2", "my note 3"]
 
+    
+def test_map_string_array_second_level_split_values_with_replace_values(
+    mocked_folio_client: FolioClient,
+):
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "description": "A holdings record",
+        "type": "object",
+        "required": [],
+        "properties": {
+            "firstLevel": {
+                "type": "object",
+                "properties": {
+                    "stringArray": {
+                        "type": "array",
+                        "description": "",
+                        "items": {"type": "string"},
+                        "uniqueItems": True,
+                    },
+                },
+                "additionalProperties": False,
+            },
+        },
+    }
+    fake_item_map = {
+        "data": [
+
+            {
+                "folio_field": "firstLevel.stringArray[0]",
+                "legacy_field": "category",
+                "value": "",
+                "description": "",
+                "rules": {"replaceValues": {"kn": "Cute Kitten", "py": "Pretty Puppy"}}
+            },
+            {
+                "folio_field": "legacyIdentifier",
+                "legacy_field": "id",
+                "value": "",
+                "description": "",
+            },
+        ]
+    }
+    record = {"id": "test_map_string_array_second_level_split_values_with_replaceValues", "category": "kn<delimiter>py"}
+    # Loop to make sure the right order occurs the first time.
+
+    tfm = MyTestableFileMapper(schema, fake_item_map, mocked_folio_client)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    assert folio_rec["firstLevel"]["stringArray"] == ["Cute Kitten", "Pretty Puppy"]
+
 
 def test_map_array_of_objects_with_string_array(mocked_folio_client: FolioClient):
     schema = {
@@ -4026,6 +4075,8 @@ def test_get_prop_same_as_get_legacy_value_mapped_value():
     mock_self.record_map = {"data": [mapping_file_entry]}
     mock_self.mapped_from_legacy_data = {"title": "title"}
     mock_self.migration_report = MigrationReport()
+    mock_self.library_configuration = Mock(spec=LibraryConfiguration)
+    mock_self.library_configuration.multi_field_delimiter = "<delimiter>"
     res2 = MappingFileMapperBase.get_prop(mock_self, legacy_object, "title", "", "")
     assert res == res2
 
@@ -4051,6 +4102,8 @@ def test_get_prop_concatenated():
     mock_self.record_map = {"data": mapping_file_entries}
     mock_self.mapped_from_legacy_data = {"title": ["firstname", "lastname"]}
     mock_self.migration_report = MigrationReport()
+    mock_self.library_configuration = Mock(spec=LibraryConfiguration)
+    mock_self.library_configuration.multi_field_delimiter = "<delimiter>"
     res2 = MappingFileMapperBase.get_prop(mock_self, legacy_object, "title", "", "")
     assert res2 == "Leif Randt"
 

--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -1954,7 +1954,7 @@ def test_map_string_array_second_level_split_values(mocked_folio_client: FolioCl
     folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
     assert folio_rec["firstLevel"]["stringArray"] == ["my note 2", "my note 3"]
 
-    
+
 def test_map_string_array_second_level_split_values_with_replace_values(
     mocked_folio_client: FolioClient,
 ):
@@ -1980,13 +1980,12 @@ def test_map_string_array_second_level_split_values_with_replace_values(
     }
     fake_item_map = {
         "data": [
-
             {
                 "folio_field": "firstLevel.stringArray[0]",
                 "legacy_field": "category",
                 "value": "",
                 "description": "",
-                "rules": {"replaceValues": {"kn": "Cute Kitten", "py": "Pretty Puppy"}}
+                "rules": {"replaceValues": {"kn": "Cute Kitten", "py": "Pretty Puppy"}},
             },
             {
                 "folio_field": "legacyIdentifier",
@@ -1996,7 +1995,10 @@ def test_map_string_array_second_level_split_values_with_replace_values(
             },
         ]
     }
-    record = {"id": "test_map_string_array_second_level_split_values_with_replaceValues", "category": "kn<delimiter>py"}
+    record = {
+        "id": "test_map_string_array_second_level_split_values_with_replaceValues",
+        "category": "kn<delimiter>py",
+    }
     # Loop to make sure the right order occurs the first time.
 
     tfm = MyTestableFileMapper(schema, fake_item_map, mocked_folio_client)

--- a/tests/test_organization_mapper.py
+++ b/tests/test_organization_mapper.py
@@ -232,6 +232,7 @@ def test_contacts_category_refdata_mapping_single(mapper):
         "e193b0d1-4674-4a9e-818b-375f013d963f"
     ]
 
+
 def test_contacts_categories_replacevalue_multiple(mapper):
     data = {
         "name": "The Vendor",  # String, required

--- a/tests/test_organization_mapper.py
+++ b/tests/test_organization_mapper.py
@@ -232,12 +232,10 @@ def test_contacts_category_refdata_mapping_single(mapper):
         "e193b0d1-4674-4a9e-818b-375f013d963f"
     ]
 
-
-@pytest.mark.skip(reason="Requires #542")
 def test_contacts_categories_replacevalue_multiple(mapper):
     data = {
         "name": "The Vendor",  # String, required
-        "code": "test_contacts_categories_replacevalue_single",  # String, required
+        "code": "test_contacts_categories_replacevalue_multiple",  # String, required
         "status": "Active",  # Enum, required
         "contact_person_f": "Joey",
         "contact_person_l": "Janeway",


### PR DESCRIPTION
This is pretty neat! It lets you, for example, have source data that looks like this

```
    data = {
        "name": "The Vendor",
        "contact_person_l": "Janeway",
        "contact_categories": "mspt^-^sls",
    }
```
    
and a mapping like this

```
        {
            "folio_field": "contacts[0].categories[0]",
            "legacy_field": "contact_categories",
            "value": "",
            "rules": {
                "replaceValues": {
                    "mspt": "e193b0d1-4674-4a9e-818b-375f013d963f",
                    "sls": "604c2c9d-ed3a-46cd-bec4-69926c303b22",
                }
            },
            "description": "",
        },
```

to get a result like this

`'categories': ['e193b0d1-4674-4a9e-818b-375f013d963f', '604c2c9d-ed3a-46cd-bec4-69926c303b22']
`