### PR TITLE
634 orders alternative implementation fetch and cache vendors only when needed close #634 close #635

### DIFF
--- a/src/folio_migration_tools/mapping_file_transformation/notes_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/notes_mapper.py
@@ -63,8 +63,7 @@ class NotesMapper(MappingFileMapperBase):
                     self.migration_report.add(Blurbs.MappedNoteTypes, note["typeId"])
                 else:
                     self.migration_report.add_general_statistics(
-                        "Notes without content that were discarded. Set some default "
-                        "value if you only intend to set the note title"
+                        "Number of discarded notes with no content"
                     )
 
     def get_notes_schema(self):

--- a/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
@@ -410,7 +410,7 @@ class CompositeOrderMapper(MappingFileMapperBase):
         else:
             self.migration_report.add(
                 Blurbs.PurchaseOrderVendorLinking,
-                "Organization identifier not in ID map/FOLIO (RECORD FAILED)",
+                "RECORD FAILED Organization identifier not in ID map/FOLIO",
             )
             raise TransformationRecordFailedError(
                 index_or_id,
@@ -422,13 +422,13 @@ class CompositeOrderMapper(MappingFileMapperBase):
         if matching_instance := self.instance_id_map.get(bib_id):
             self.migration_report.add(
                 Blurbs.PurchaseOrderInstanceLinking,
-                "Instance linked using instances_id_map",
+                "Instances linked using instances_id_map",
             )
             return matching_instance[1]
         else:
             self.migration_report.add(
                 Blurbs.PurchaseOrderInstanceLinking,
-                "Istance not linked - bib identifier not in instances_id_map",
+                "Bib identifier not in instances_id_map, no instance linked",
             )
             Helper.log_data_issue(
                 index_or_id,

--- a/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
@@ -360,7 +360,7 @@ class CompositeOrderMapper(MappingFileMapperBase):
 
         # Replace legacy bib ID with instance UUID from map
         bib_id = composite_order["compositePoLines"][0].pop("instanceId", "")
-        if matching_instance := self.get_folio_intance_uuid(index_or_id, bib_id):
+        if matching_instance := self.get_folio_instance_uuid(index_or_id, bib_id):
             composite_order["compositePoLines"][0]["instanceId"] = matching_instance
 
         return composite_order
@@ -418,7 +418,7 @@ class CompositeOrderMapper(MappingFileMapperBase):
                 org_code,
             )
 
-    def get_folio_intance_uuid(self, index_or_id, bib_id):
+    def get_folio_instance_uuid(self, index_or_id, bib_id):
         if matching_instance := self.instance_id_map.get(bib_id):
             self.migration_report.add(
                 Blurbs.PurchaseOrderInstanceLinking,

--- a/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
@@ -392,7 +392,7 @@ class CompositeOrderMapper(MappingFileMapperBase):
             )
             if matching_org := self.organizations_id_map.get(org_code):
                 return matching_org[1]
-        
+
         if matching_org := self.get_matching_record_from_folio(
             index_or_id,
             self.folio_organization_cache,
@@ -406,7 +406,7 @@ class CompositeOrderMapper(MappingFileMapperBase):
                 "Organizations not in ID map, linked using FOLIO lookup",
             )
             return matching_org["id"]
-        
+
         else:
             self.migration_report.add(
                 Blurbs.PurchaseOrderVendorLinking,

--- a/src/folio_migration_tools/migration_tasks/orders_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/orders_transformer.py
@@ -79,6 +79,7 @@ class OrdersTransformer(MigrationTaskBase):
             self.folio_client,
             self.library_configuration,
             self.orders_map,
+            self.load_id_map(self.folder_structure.organizations_id_map_path, True),
             self.load_id_map(self.folder_structure.instance_id_map_path, True),
             self.load_ref_data_mapping_file(
                 "acquisitionMethod",

--- a/src/folio_migration_tools/migration_tasks/orders_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/orders_transformer.py
@@ -165,13 +165,12 @@ class OrdersTransformer(MigrationTaskBase):
                     folio_rec, legacy_id = self.mapper.do_map(
                         record, f"row {idx}", FOLIONamespaces.orders, True
                     )
+                    self.mapper.perform_additional_mapping(legacy_id, folio_rec)
+
                     self.mapper.migration_report.add_general_statistics(
                         "TOTAL Purchase Order Lines created"
                     )
-
                     self.mapper.report_folio_mapping(folio_rec, self.mapper.composite_order_schema)
-
-                    # Add notes
                     self.mapper.notes_mapper.map_notes(
                         record,
                         legacy_id,

--- a/src/folio_migration_tools/migration_tasks/organization_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/organization_transformer.py
@@ -67,6 +67,9 @@ class OrganizationTransformer(MigrationTaskBase):
 
         self.results_path = self.folder_structure.created_objects_path
         self.failed_files: List[str] = []
+        self.organizations_id_map = self.load_id_map(
+            self.folder_structure.organizations_id_map_path
+        )
 
         self.folio_keys = []
         self.folio_keys = MappingFileMapperBase.get_mapped_folio_properties_from_map(
@@ -155,6 +158,9 @@ class OrganizationTransformer(MigrationTaskBase):
                         FOLIONamespaces.organizations,
                     )
                     folio_rec = self.clean_org(folio_rec)
+                    self.organizations_id_map[legacy_id] = self.mapper.get_id_map_tuple(
+                        legacy_id, folio_rec, self.object_type
+                    )
 
                     Helper.write_to_file(results_file, folio_rec)
 
@@ -225,6 +231,9 @@ class OrganizationTransformer(MigrationTaskBase):
                 self.mapper.mapped_legacy_fields,
             )
 
+            self.mapper.save_id_map_file(
+                self.folder_structure.organizations_id_map_path, self.organizations_id_map
+            )
         self.clean_out_empty_logs()
 
         logging.info("All done!")

--- a/src/folio_migration_tools/report_blurbs.py
+++ b/src/folio_migration_tools/report_blurbs.py
@@ -251,6 +251,14 @@ class Blurbs:
         "POL location mapping",
         "This is the location for for the purchase order line.",
     )
+    PurchaseOrderVendorLinking = (
+        "Linked Organizations",
+        "All purchase orders must be linked to an organization.",
+    )
+    PurchaseOrderInstanceLinking = (
+        "Linked Instances",
+        "Purchase Oreder Lines can but do not have to be linked to instances",
+    )
     StatisticalCodeMapping = ("Statistical code mapping", "")
     HoldingsRecordIdMapping = ("Holdings IDs mapped", "")
     UnmappedProperties = ("Unmapped properties", "")

--- a/src/folio_migration_tools/report_blurbs.py
+++ b/src/folio_migration_tools/report_blurbs.py
@@ -257,7 +257,7 @@ class Blurbs:
     )
     PurchaseOrderInstanceLinking = (
         "Linked Instances",
-        "Purchase Oreder Lines can but do not have to be linked to instances",
+        "Purchase Order Lines can but do not have to be linked to instances",
     )
     StatisticalCodeMapping = ("Statistical code mapping", "")
     HoldingsRecordIdMapping = ("Holdings IDs mapped", "")

--- a/src/folio_migration_tools/report_blurbs.py
+++ b/src/folio_migration_tools/report_blurbs.py
@@ -253,7 +253,7 @@ class Blurbs:
     )
     PurchaseOrderVendorLinking = (
         "Linked Organizations",
-        "All purchase orders must be linked to an organization.",
+        "All purchase orders MUST be linked to an organization.",
     )
     PurchaseOrderInstanceLinking = (
         "Linked Instances",

--- a/src/folio_migration_tools/test_infrastructure/mocked_classes.py
+++ b/src/folio_migration_tools/test_infrastructure/mocked_classes.py
@@ -77,6 +77,13 @@ def folio_get_all_mocked(ref_data_path, array_name, query="", limit=10):
         and query == '?query=(code=="EBSCO")'
     ):
         yield from [{"id": "some id", "code": "some code", "name": "EBSCO Information Services"}]
+
+    elif (
+        ref_data_path == "/organizations-storage/organizations"
+        and query == '?query=(code=="LisasAwesomeStartup")'
+    ):
+        yield from []
+
     elif ref_data_path == "/organizations-storage/organizations":
         yield from [
             {"id": "837d04b6-d81c-4c49-9efd-2f62515999b3", "code": "GOBI"},

--- a/src/folio_migration_tools/test_infrastructure/mocked_classes.py
+++ b/src/folio_migration_tools/test_infrastructure/mocked_classes.py
@@ -72,6 +72,11 @@ def folio_get_all_mocked(ref_data_path, array_name, query="", limit=10):
             {"id": "837d04b6-d81c-4c49-9efd-2f62515999b3", "name": "Consortium"},
             {"id": "fc54327d-fd60-4f6a-ba37-a4375511b91b", "name": "Unspecified"},
         ]
+    elif (
+        ref_data_path == "/organizations-storage/organizations"
+        and query == '?query=(code=="EBSCO")'
+    ):
+        yield from [{"id": "some id", "code": "some code", "name": "EBSCO Information Services"}]
     elif ref_data_path == "/organizations-storage/organizations":
         yield from [
             {"id": "837d04b6-d81c-4c49-9efd-2f62515999b3", "code": "GOBI"},
@@ -173,7 +178,6 @@ def folio_get_all_mocked(ref_data_path, array_name, query="", limit=10):
 
     elif ref_data_path == "/users" and query == '?query=(externalSystemId=="Some external id")':
         yield from [{"id": "some id", "barcode": "some barcode", "patronGroup": "some group"}]
-
     elif ref_data_path == "/users" and query == '?query=(barcode=="u123")':
         yield from [{"id": "user123", "barcode": "u123", "patronGroup": "some group"}]
     elif ref_data_path == "/users" and query == '?query=(barcode=="u456")':

--- a/tests/test_orders_mapper.py
+++ b/tests/test_orders_mapper.py
@@ -421,3 +421,40 @@ def test_multiple_pols_with_one_or_more_notes(mapper):
         str(mapper.extradata_writer.cache).count(composite_orders[1]["compositePoLines"][0]["id"])
         == 1
     )
+
+
+def test_perform_additional_mapping(mapper):
+    folio_po = {
+        "id": "b90e41f3-8987-58fd-99be-b91068509aa0",
+        "metadata": {
+            "createdDate": "2023-05-11T09:58:44.250",
+            "createdByUserId": "f6a6a201-51f6-46f7-b671-c2813cd0558e",
+            "updatedDate": "2023-05-11T09:58:44.250",
+            "updatedByUserId": "f6a6a201-51f6-46f7-b671-c2813cd0558e",
+        },
+        "poNumber": "o124",
+        "orderType": "One-Time",
+        "vendor": "EBSCO",
+        "compositePoLines": [
+            {
+                "locations": [
+                    {"locationId": "184aae84-a5bf-4c6a-85ba-4a7c73026cd5", "quantity": "2"}
+                ],
+                "id": "a10af88f-100c-4c5e-8ef3-c95fc85590c2",
+                "instanceId": "1",
+                "acquisitionMethod": "837d04b6-d81c-4c49-9efd-2f62515999b3",
+                "cost": {
+                    "currency": "USD",
+                    "quantityPhysical": "1",
+                    "poLineEstimatedPrice": "125.00",
+                },
+                "orderFormat": "Electronic Resource",
+                "source": "API",
+                "titleOrPackage": "Once upon a time...",
+            }
+        ],
+    }
+
+    folio_po = mapper.perform_additional_mapping("1", folio_po)
+    assert folio_po["vendor"] == "some id"
+    assert folio_po["compositePoLines"][0]["instanceId"] == "ae1daef2-ddea-4d87-a434-3aa98ed3e687"

--- a/tests/test_orders_mapper.py
+++ b/tests/test_orders_mapper.py
@@ -315,10 +315,7 @@ def test_composite_order_with_one_pol_mapping(mapper):
     assert (
         composite_order_with_pol["compositePoLines"][0]["titleOrPackage"] == "Once upon a time..."
     )
-    assert (
-        composite_order_with_pol["compositePoLines"][0]["instanceId"]
-        == "1"
-    )
+    assert composite_order_with_pol["compositePoLines"][0]["instanceId"] == "1"
     assert composite_order_with_pol["compositePoLines"][0]["cost"]["currency"] == "USD"
     assert composite_order_with_pol["compositePoLines"][0]["cost"]["quantityPhysical"] == "1"
     assert (
@@ -455,6 +452,7 @@ def test_perform_additional_mapping_get_org_from_folio(mapper):
     folio_po = mapper.perform_additional_mapping("1", folio_po)
     assert folio_po["vendor"] == "some id"
 
+
 def test_perform_additional_mapping_org_and_instance_uuids_from_id_maps(mapper):
     folio_po = {
         "id": "b90e41f3-8987-58fd-99be-b91068509aa0",
@@ -484,7 +482,6 @@ def test_perform_additional_mapping_org_and_instance_uuids_from_id_maps(mapper):
     folio_po = mapper.perform_additional_mapping("1", folio_po)
     assert folio_po["vendor"] == "bbf61aa3-05ea-5d15-99c8-e3e547001543"
     assert folio_po["compositePoLines"][0]["instanceId"] == "ae1daef2-ddea-4d87-a434-3aa98ed3e687"
-
 
 
 def test_perform_additional_mapping_org_uuid_no_match(mapper):

--- a/tests/test_orders_mapper.py
+++ b/tests/test_orders_mapper.py
@@ -286,7 +286,7 @@ def test_composite_order_mapping(mapper):
     composite_order, idx = mapper.do_map(data, data["order_number"], FOLIONamespaces.orders)
     assert composite_order["id"] == "6bf8d907-054d-53ad-9031-7a45887fcafa"
     assert composite_order["poNumber"] == "o123"
-    assert composite_order["vendor"] == "fc54327d-fd60-4f6a-ba37-a4375511b91b"
+    assert composite_order["vendor"] == "EBSCO"
     assert composite_order["orderType"] == "One-Time"
 
 
@@ -314,7 +314,7 @@ def test_composite_order_with_one_pol_mapping(mapper):
     )
     assert (
         composite_order_with_pol["compositePoLines"][0]["instanceId"]
-        == "ae1daef2-ddea-4d87-a434-3aa98ed3e687"
+        == "1"
     )
     assert composite_order_with_pol["compositePoLines"][0]["cost"]["currency"] == "USD"
     assert composite_order_with_pol["compositePoLines"][0]["cost"]["quantityPhysical"] == "1"


### PR DESCRIPTION
### Major changes

**Organizations**
The organizations transformer now creates an organizayions_id_map 

**Orders**
Linking to FOLIO organizations and linking to FOLIO instances has been moved out of the get_prop method and into a "perform additional mapping". The main purpose of this was to circumvent problems (repeated lookups, incorrect reports) caused by https://github.com/FOLIO-FSE/folio_migration_tools/issues/628

Instead of fetching all organizations form FOLIO and using that as an ID map, the Order mapper now
1. Looks up the organization identifier in the organizaitons_id_map
2. If it doesn't find the identifier in the map, looks the identifier up (as property "Code") in FOLIO
3. If it still doesn't find an organization, the order fails