### PR TITLE
Updating smtp check in loans migrator and bumping codecov action version

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -47,7 +47,7 @@ jobs:
 
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3        
+      uses: codecov/codecov-action@v3.1.4        
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./


### PR DESCRIPTION
Closes #500 

This adds a check for either the lack of any `/smtp-configuration` records OR the presence of the string `"disabled"` in the `index 0` SMTP configuration's host parameter in Nolana or newer system. If present, SMTP is considered disabled by the system and the the `LoansMigrator` task will continue without pausing for 10 seconds.