### PR TITLE
Contributor type text mapping and source=FOLIO holdings hrid handling fixes

### DIFF
--- a/src/folio_migration_tools/marc_rules_transformation/conditions.py
+++ b/src/folio_migration_tools/marc_rules_transformation/conditions.py
@@ -253,7 +253,15 @@ class Conditions:
         self, legacy_id, value, parameter, marc_field: field.Field
     ):
         subfields_to_concat = parameter.get("subfieldsToConcat", [])
-        concat_string = " ".join(marc_field.get_subfields(*subfields_to_concat))
+        subfields_to_stop_concat = parameter.get("subfieldsToStopConcat", [])
+        concat_subfields = []
+        for t in marc_field.subfields:
+            if t[0] in subfields_to_concat:
+                if t[0] not in subfields_to_stop_concat:
+                    concat_subfields.append(t[1])
+                else:
+                    break
+        concat_string = " ".join(concat_subfields)
         return f"{value} {concat_string}"
 
     def condition_get_value_if_subfield_is_empty(
@@ -647,7 +655,7 @@ class Conditions:
                 if normalized_subfield in [cont_type["code"], cont_type["name"]]:
                     return cont_type["name"]
         try:
-            marc_field.get_subfields("j", "e")[0]
+            return value
         except IndexError as ee:
             return ""
 

--- a/src/folio_migration_tools/marc_rules_transformation/conditions.py
+++ b/src/folio_migration_tools/marc_rules_transformation/conditions.py
@@ -255,12 +255,12 @@ class Conditions:
         subfields_to_concat = parameter.get("subfieldsToConcat", [])
         subfields_to_stop_concat = parameter.get("subfieldsToStopConcat", [])
         concat_subfields = []
-        for t in marc_field.subfields:
-            if t[0] in subfields_to_concat:
-                if t[0] not in subfields_to_stop_concat:
-                    concat_subfields.append(t[1])
-                else:
-                    break
+        subfields = marc_field.subfields
+        for t in subfields:
+            if t[0] in subfields_to_stop_concat:
+                break
+            elif t[0] in subfields_to_concat:
+                concat_subfields.append(t[1])
         concat_string = " ".join(concat_subfields)
         return f"{value} {concat_string}"
 

--- a/src/folio_migration_tools/marc_rules_transformation/rules_mapper_base.py
+++ b/src/folio_migration_tools/marc_rules_transformation/rules_mapper_base.py
@@ -180,7 +180,7 @@ class RulesMapperBase(MapperBase):
         stripped_conds = mapping["rules"][0]["conditions"][0]["type"].split(",")
         condition_types = list(map(str.strip, stripped_conds))
         parameter = mapping["rules"][0]["conditions"][0].get("parameter", {})
-        if mapping.get("applyRulesOnConcatenatedData", ""):
+        if mapping.get("applyRulesOnConcatenatedData", ""):  # TODO: implement subfieldDelimiter
             value = " ".join(marc_field.get_subfields(*mapping["subfield"]))
             return self.apply_rule(legacy_id, value, condition_types, marc_field, parameter)
         elif mapping.get("subfield", []):
@@ -189,7 +189,7 @@ class RulesMapperBase(MapperBase):
                 self.apply_rule(legacy_id, x, condition_types, marc_field, parameter)
                 for x in subfields
             ]
-            return " ".join(set(x))
+            return " ".join(dict.fromkeys(x))  # Create an ordered set of unique values before join
         else:
             value1 = marc_field.format_field() if marc_field else ""
             return self.apply_rule(legacy_id, value1, condition_types, marc_field, parameter)

--- a/src/folio_migration_tools/marc_rules_transformation/rules_mapper_holdings.py
+++ b/src/folio_migration_tools/marc_rules_transformation/rules_mapper_holdings.py
@@ -15,6 +15,7 @@ from folio_migration_tools.custom_exceptions import TransformationRecordFailedEr
 from folio_migration_tools.helper import Helper
 from folio_migration_tools.holdings_helper import HoldingsHelper
 from folio_migration_tools.library_configuration import FileDefinition
+from folio_migration_tools.library_configuration import HridHandling
 from folio_migration_tools.library_configuration import LibraryConfiguration
 from folio_migration_tools.marc_rules_transformation.conditions import Conditions
 from folio_migration_tools.marc_rules_transformation.holdings_statementsparser import (
@@ -253,7 +254,10 @@ class RulesMapperHoldings(RulesMapperBase):
         self.pick_first_location_if_many(folio_holding, legacy_ids)
         self.parse_coded_holdings_statements(marc_record, folio_holding, legacy_ids)
         HoldingsHelper.handle_notes(folio_holding)
-        if self.task_configuration.create_source_records:
+        if (
+            self.task_configuration.create_source_records
+            or self.task_configuration.hrid_handling == HridHandling.preserve001
+        ):
             self.hrid_handler.handle_hrid(
                 FOLIONamespaces.holdings, folio_holding, marc_record, legacy_ids
             )

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -15,7 +15,7 @@ def test_condition_trim_period():
 
 def test_condition_concat_subfields_by_name():
     mock = Mock(spec=Conditions)
-    parameter = {"subfieldsToConcat": ["q"]}
+    parameter = {"subfieldsToConcat": ["q"], "subfieldsToStopConcat": ["z"]}
     legacy_id = "legacy_id"
     marc_field = Field(
         tag="245",
@@ -24,6 +24,8 @@ def test_condition_concat_subfields_by_name():
             Subfield(code="a", value="value"),
             Subfield(code="b", value="from journeyman to master /"),
             Subfield(code="q", value="stuff to concatenate"),
+            Subfield(code="z", value="stop here"),
+            Subfield(code="q", value="more stuff to concatenate"),
         ],
     )
     res = Conditions.condition_concat_subfields_by_name(

--- a/tests/test_holdings_statementsparser.py
+++ b/tests/test_holdings_statementsparser.py
@@ -95,9 +95,9 @@ def test_linked_fields_1():
             Subfield(code="8", value="1"),
             Subfield(code="a", value="v."),
             Subfield(code="b", value="no."),
-            Subfield(code="i", value="(year)"), 
+            Subfield(code="i", value="(year)"),
             Subfield(code="j", value="(month)"),
-            Subfield(code="k", value="(day)")
+            Subfield(code="k", value="(day)"),
         ],
     )
     linked_value_field = Field(
@@ -109,7 +109,7 @@ def test_linked_fields_1():
             Subfield(code="b", value="2"),
             Subfield(code="i", value="2006"),
             Subfield(code="j", value="01"),
-            Subfield(code="k", value="09")
+            Subfield(code="k", value="09"),
         ],
     )
 
@@ -127,7 +127,7 @@ def test_linked_fields_2():
             Subfield(code="a", value="v."),
             Subfield(code="b", value="no."),
             Subfield(code="i", value="(year)"),
-            Subfield(code="j", value="(month)")
+            Subfield(code="j", value="(month)"),
         ],
     )
     linked_value_field1 = Field(
@@ -138,7 +138,7 @@ def test_linked_fields_2():
             Subfield(code="a", value="34"),
             Subfield(code="b", value="48"),
             Subfield(code="i", value="2005"),
-            Subfield(code="j", value="11")
+            Subfield(code="j", value="11"),
         ],
     )
     linked_value_field2 = Field(
@@ -149,7 +149,7 @@ def test_linked_fields_2():
             Subfield(code="a", value="35"),
             Subfield(code="b", value="2"),
             Subfield(code="i", value="2006"),
-            Subfield(code="j", value="01")
+            Subfield(code="j", value="01"),
         ],
     )
 
@@ -170,7 +170,7 @@ def test_linked_fields_3():
             Subfield(code="a", value="v."),
             Subfield(code="b", value=""),
             Subfield(code="i", value="(year)"),
-            Subfield(code="j", value="(month)")
+            Subfield(code="j", value="(month)"),
         ],
     )
     linked_value_field1 = Field(
@@ -200,7 +200,7 @@ def test_linked_fields_4():
             Subfield(code="a", value="v."),
             Subfield(code="b", value="no."),
             Subfield(code="i", value="(year)"),
-            Subfield(code="j", value="(season)")
+            Subfield(code="j", value="(season)"),
         ],
     )
     linked_value_field1 = Field(
@@ -225,10 +225,7 @@ def test_linked_fields_5():
     pattern_field = Field(
         tag="853",
         indicators=["0", "1"],
-        subfields=[
-            Subfield(code="8", value="1"),
-            Subfield(code="i", value="(year)")
-        ],
+        subfields=[Subfield(code="8", value="1"), Subfield(code="i", value="(year)")],
     )
     linked_value_field1 = Field(
         tag="863",
@@ -249,11 +246,12 @@ def test_linked_fields_6():
         tag="853",
         indicators=["0", "1"],
         subfields=[
-            Subfield(code="8", value="1"), 
+            Subfield(code="8", value="1"),
             Subfield(code="a", value="v."),
             Subfield(code="b", value="no."),
             Subfield(code="i", value="(year)"),
-            Subfield(code="j", value="(month)")],
+            Subfield(code="j", value="(month)"),
+        ],
     )
     linked_value_field1 = Field(
         tag="863",
@@ -263,7 +261,7 @@ def test_linked_fields_6():
             Subfield(code="a", value="1-48"),
             Subfield(code="b", value="1-4"),
             Subfield(code="i", value="1966-2014"),
-            Subfield(code="j", value="11")
+            Subfield(code="j", value="11"),
         ],
     )
 
@@ -281,7 +279,7 @@ def test_linked_fields_7():
             Subfield(code="a", value="v."),
             Subfield(code="b", value=" "),
             Subfield(code="i", value="(year)"),
-            Subfield(code="j", value="(month)")
+            Subfield(code="j", value="(month)"),
         ],
     )
     linked_value_field1 = Field(
@@ -292,7 +290,7 @@ def test_linked_fields_7():
             Subfield(code="a", value="111-111"),
             Subfield(code="b", value="5-6"),
             Subfield(code="i", value="2004"),
-            Subfield(code="j", value="09/10-11/12")
+            Subfield(code="j", value="09/10-11/12"),
         ],
     )
 

--- a/tests/test_rules_mapper_holdings.py
+++ b/tests/test_rules_mapper_holdings.py
@@ -281,7 +281,7 @@ def test_create_source_records_equals_false():
         tenant_id=folio.tenant_id,
         okapi_username=folio.username,
         okapi_password=folio.password,
-        folio_release=FolioRelease.morning_glory,
+        folio_release=FolioRelease.orchid,
         library_name="Test Run Library",
         log_level_debug=False,
         iteration_identifier="I have no clue",
@@ -328,6 +328,65 @@ def test_create_source_records_equals_false():
         assert res
         assert res["permanentLocationId"] == "f34d27c6-a8eb-461b-acd6-5dea81771e70"
         assert res.get("hrid", False) is False
+        assert len(res["administrativeNotes"]) > 0
+        assert res["callNumber"] == "QB611 .C44"
+        assert res["callNumberTypeId"] == "95467209-6d7b-468b-94df-0f5d7ad2747d"
+
+
+def test_create_source_records_equals_false_preserve001():
+    folio = mocked_classes.mocked_folio_client()
+    lib = LibraryConfiguration(
+        okapi_url=folio.okapi_url,
+        tenant_id=folio.tenant_id,
+        okapi_username=folio.username,
+        okapi_password=folio.password,
+        folio_release=FolioRelease.orchid,
+        library_name="Test Run Library",
+        log_level_debug=False,
+        iteration_identifier="I have no clue",
+        base_folder="/",
+    )
+    conf = HoldingsMarcTransformer.TaskConfiguration(
+        name="test",
+        migration_task_type="HoldingsTransformer",
+        hrid_handling=HridHandling.preserve001,
+        files=[],
+        ils_flavour=IlsFlavour.voyager,
+        legacy_id_marc_path="001",
+        location_map_file_name="",
+        default_call_number_type_name="Dewey Decimal classification",
+        fallback_holdings_type_id="03c9c400-b9e3-4a07-ac0e-05ab470233ed",
+        create_source_records=False,
+    )
+    parent_id_map: dict[str, tuple] = {}
+    location_map = [
+        {"legacy_code": "jnlDesk", "folio_code": "KU/CC/DI/2"},
+        {"legacy_code": "*", "folio_code": "KU/CC/DI/2"},
+    ]
+    mapper = RulesMapperHoldings(folio, location_map, conf, lib, parent_id_map, [])
+    mapper.folio_client = folio
+    mapper.migration_report = MigrationReport()
+    path = "./tests/test_data/mfhd/holding.mrc"
+    with open(path, "rb") as marc_file:
+        reader = MARCReader(marc_file, to_unicode=True, permissive=True)
+        reader.hide_utf8_warnings = True
+        reader.force_utf8 = True
+        record: Record = None
+        mapper.parent_id_map = {
+            "7611780": (
+                "7611780",
+                "9d1673a3-a546-5afa-b0fb-5ab971f73eca",
+                "in00000000005",
+            )
+        }
+        record = next(reader)
+        ids = RulesMapperHoldings.get_legacy_ids(mapper, record, 1)
+        res = mapper.parse_record(
+            record, FileDefinition(file_name="", suppressed=False, staff_suppressed=False), ids
+        )[0]
+        assert res
+        assert res["permanentLocationId"] == "f34d27c6-a8eb-461b-acd6-5dea81771e70"
+        assert res.get("hrid", False) == "000000167"
         assert len(res["administrativeNotes"]) > 0
         assert res["callNumber"] == "QB611 .C44"
         assert res["callNumberTypeId"] == "95467209-6d7b-468b-94df-0f5d7ad2747d"


### PR DESCRIPTION
Fix for failed contributor type text mapping when no ref data map is found, and some formatting fixes. 

Added missing `return` statement in `set_contributor_type_text` condition and added a test. I also changed the handling when there is no ref data match for `$4` or `$e` to use the `value` passed into the condition, rather than hard-coding to the first `$j` or `$e`

Fixes #647