### PR TITLE
Environment variable defaults

### DIFF
--- a/src/folio_migration_tools/__main__.py
+++ b/src/folio_migration_tools/__main__.py
@@ -19,7 +19,7 @@ import i18n
 i18n.load_config(Path(__file__).parents[2] / "i18n_config.py")
 
 
-def parse_args():
+def parse_args(args):
     task_classes = iter(inheritors(migration_task_base.MigrationTaskBase))
     parser = PromptParser()
     parser.add_argument(
@@ -59,14 +59,14 @@ def parse_args():
         default="en",
         prompt=False,
     )
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def main():
     try:
         task_classes = list(inheritors(migration_task_base.MigrationTaskBase))
 
-        args = parse_args()
+        args = parse_args(sys.argv[1:])
         i18n.set("locale", args.report_language)
         with open(args.configuration_path) as config_file_path:
             try:

--- a/src/folio_migration_tools/__main__.py
+++ b/src/folio_migration_tools/__main__.py
@@ -2,6 +2,7 @@ import json
 import logging
 import sys
 from pathlib import Path
+from os import environ
 
 import httpx
 import humps
@@ -21,20 +22,34 @@ i18n.load_config(Path(__file__).parents[2] / "i18n_config.py")
 def parse_args():
     task_classes = iter(inheritors(migration_task_base.MigrationTaskBase))
     parser = PromptParser()
-    parser.add_argument("configuration_path", help="Path to configuration file")
+    parser.add_argument(
+        "configuration_path",
+        help="Path to configuration file",
+        nargs="?",
+        prompt="FOLIO_MIGRATION_TOOLS_CONFIGURATION_PATH" not in environ,
+        default=environ.get("FOLIO_MIGRATION_TOOLS_CONFIGURATION_PATH"),
+    )
     tasks_string = ", ".join(sorted(tc.__name__ for tc in task_classes))
+
     parser.add_argument(
         "task_name",
         help=("Task name. Use one of: " f"{tasks_string}"),
+        nargs="?",
+        prompt="FOLIO_MIGRATION_TOOLS_TASK_NAME" not in environ,
+        default=environ.get("FOLIO_MIGRATION_TOOLS_TASK_NAME"),
     )
     parser.add_argument(
         "--okapi_password",
         help="pasword for the tenant in the configuration file",
+        prompt="FOLIO_MIGRATION_TOOLS_OKAPI_PASSWORD" not in environ,
+        default=environ.get("FOLIO_MIGRATION_TOOLS_OKAPI_PASSWORD"),
         secure=True,
     )
     parser.add_argument(
         "--base_folder_path",
         help=("path to the base folder for this library. Built on migration_repo_template"),
+        prompt="FOLIO_MIGRATION_TOOLS_BASE_FOLDER_PATH" not in environ,
+        default=environ.get("FOLIO_MIGRATION_TOOLS_BASE_FOLDER_PATH"),
     )
     parser.add_argument(
         "--report_language",

--- a/src/folio_migration_tools/__main__.py
+++ b/src/folio_migration_tools/__main__.py
@@ -56,7 +56,7 @@ def parse_args(args):
         help=(
             "Language to write the reports. Defaults english for untranslated languages/strings."
         ),
-        default="en",
+        default=environ.get("FOLIO_MIGRATION_TOOLS_REPORT_LANGUAGE", "en"),
         prompt=False,
     )
     return parser.parse_args(args)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 from folio_migration_tools import __main__
 from folio_migration_tools.migration_tasks.migration_task_base import MigrationTaskBase
+from unittest import mock
 
 
 def test_inheritance():
@@ -16,3 +17,89 @@ def test_inheritance():
     assert "BibsTransformer" in inheritors
     assert "BatchPoster" in inheritors
     assert "AuthorityTransformer" in inheritors
+
+
+@mock.patch("getpass.getpass", create=True)
+@mock.patch("builtins.input", create=True)
+def test_arg_prompts(insecure_inputs, secure_inputs):
+    secure_inputs.side_effect = ["okapi_password"]
+    insecure_inputs.side_effect = ["config_path", "task_name", "folder_path"]
+    args = __main__.parse_args([])
+    assert args.__dict__ == {
+        "configuration_path": "config_path",
+        "task_name": "task_name",
+        "base_folder_path": "folder_path",
+        "okapi_password": "okapi_password",
+    }
+
+
+@mock.patch("getpass.getpass", create=True)
+@mock.patch("builtins.input", create=True)
+def test_args_positionally(insecure_inputs, secure_inputs):
+    args = __main__.parse_args(
+        [
+            "config_path",
+            "task_name",
+            "--base_folder_path",
+            "folder_path",
+            "--okapi_password",
+            "okapi_password",
+        ]
+    )
+    assert args.__dict__ == {
+        "configuration_path": "config_path",
+        "task_name": "task_name",
+        "base_folder_path": "folder_path",
+        "okapi_password": "okapi_password",
+    }
+
+
+@mock.patch("getpass.getpass", create=True)
+@mock.patch("builtins.input", create=True)
+@mock.patch.dict(
+    "os.environ",
+    {
+        "FOLIO_MIGRATION_TOOLS_CONFIGURATION_PATH": "config_path",
+        "FOLIO_MIGRATION_TOOLS_TASK_NAME": "task_name",
+        "FOLIO_MIGRATION_TOOLS_BASE_FOLDER_PATH": "folder_path",
+        "FOLIO_MIGRATION_TOOLS_OKAPI_PASSWORD": "okapi_password",
+    },
+)
+def test_args_from_env(insecure_inputs, secure_inputs):
+    args = __main__.parse_args([])
+    assert args.__dict__ == {
+        "configuration_path": "config_path",
+        "task_name": "task_name",
+        "base_folder_path": "folder_path",
+        "okapi_password": "okapi_password",
+    }
+
+
+@mock.patch("getpass.getpass", create=True)
+@mock.patch("builtins.input", create=True)
+@mock.patch.dict(
+    "os.environ",
+    {
+        "FOLIO_MIGRATION_TOOLS_CONFIGURATION_PATH": "not_config_path",
+        "FOLIO_MIGRATION_TOOLS_TASK_NAME": "not_task_name",
+        "FOLIO_MIGRATION_TOOLS_BASE_FOLDER_PATH": "not_folder_path",
+        "FOLIO_MIGRATION_TOOLS_OKAPI_PASSWORD": "not_okapi_password",
+    },
+)
+def test_args_overriding_env(insecure_inputs, secure_inputs):
+    args = __main__.parse_args(
+        [
+            "config_path",
+            "task_name",
+            "--base_folder_path",
+            "folder_path",
+            "--okapi_password",
+            "okapi_password",
+        ]
+    )
+    assert args.__dict__ == {
+        "configuration_path": "config_path",
+        "task_name": "task_name",
+        "base_folder_path": "folder_path",
+        "okapi_password": "okapi_password",
+    }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,6 +30,7 @@ def test_arg_prompts(insecure_inputs, secure_inputs):
         "task_name": "task_name",
         "base_folder_path": "folder_path",
         "okapi_password": "okapi_password",
+        "report_language": "en",
     }
 
 
@@ -51,6 +52,7 @@ def test_args_positionally(insecure_inputs, secure_inputs):
         "task_name": "task_name",
         "base_folder_path": "folder_path",
         "okapi_password": "okapi_password",
+        "report_language": "en",
     }
 
 
@@ -63,6 +65,7 @@ def test_args_positionally(insecure_inputs, secure_inputs):
         "FOLIO_MIGRATION_TOOLS_TASK_NAME": "task_name",
         "FOLIO_MIGRATION_TOOLS_BASE_FOLDER_PATH": "folder_path",
         "FOLIO_MIGRATION_TOOLS_OKAPI_PASSWORD": "okapi_password",
+        "FOLIO_MIGRATION_TOOLS_REPORT_LANGUAGE": "fr",
     },
 )
 def test_args_from_env(insecure_inputs, secure_inputs):
@@ -72,6 +75,7 @@ def test_args_from_env(insecure_inputs, secure_inputs):
         "task_name": "task_name",
         "base_folder_path": "folder_path",
         "okapi_password": "okapi_password",
+        "report_language": "fr",
     }
 
 
@@ -84,6 +88,7 @@ def test_args_from_env(insecure_inputs, secure_inputs):
         "FOLIO_MIGRATION_TOOLS_TASK_NAME": "not_task_name",
         "FOLIO_MIGRATION_TOOLS_BASE_FOLDER_PATH": "not_folder_path",
         "FOLIO_MIGRATION_TOOLS_OKAPI_PASSWORD": "not_okapi_password",
+        "FOLIO_MIGRATION_TOOLS_REPORT_LANGUAGE": "not_fr",
     },
 )
 def test_args_overriding_env(insecure_inputs, secure_inputs):
@@ -95,6 +100,8 @@ def test_args_overriding_env(insecure_inputs, secure_inputs):
             "folder_path",
             "--okapi_password",
             "okapi_password",
+            "--report_language",
+            "fr",
         ]
     )
     assert args.__dict__ == {
@@ -102,4 +109,5 @@ def test_args_overriding_env(insecure_inputs, secure_inputs):
         "task_name": "task_name",
         "base_folder_path": "folder_path",
         "okapi_password": "okapi_password",
+        "report_language": "fr",
     }


### PR DESCRIPTION
Revolves #683

If we still want prompting behavior with env var defaults, we could consider a separate env var for that - PromptParser has an env var it respects to disable prompts.

Also, I'm not sure of the right place in the documentation for this.
