### PR TITLE
Allow Task Name as only positional param when config env var

### DIFF
--- a/src/folio_migration_tools/__main__.py
+++ b/src/folio_migration_tools/__main__.py
@@ -25,7 +25,7 @@ def parse_args(args):
     parser.add_argument(
         "configuration_path",
         help="Path to configuration file",
-        nargs="?",
+        nargs="?" if "FOLIO_MIGRATION_TOOLS_CONFIGURATION_PATH" in environ else None,
         prompt="FOLIO_MIGRATION_TOOLS_CONFIGURATION_PATH" not in environ,
         default=environ.get("FOLIO_MIGRATION_TOOLS_CONFIGURATION_PATH"),
     )
@@ -34,7 +34,7 @@ def parse_args(args):
     parser.add_argument(
         "task_name",
         help=("Task name. Use one of: " f"{tasks_string}"),
-        nargs="?",
+        nargs="?" if "FOLIO_MIGRATION_TOOLS_TASK_NAME" in environ else None,
         prompt="FOLIO_MIGRATION_TOOLS_TASK_NAME" not in environ,
         default=environ.get("FOLIO_MIGRATION_TOOLS_TASK_NAME"),
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,10 +21,14 @@ def test_inheritance():
 
 @mock.patch("getpass.getpass", create=True)
 @mock.patch("builtins.input", create=True)
+@mock.patch.dict(
+    "os.environ",
+    {},
+)
 def test_arg_prompts(insecure_inputs, secure_inputs):
     secure_inputs.side_effect = ["okapi_password"]
-    insecure_inputs.side_effect = ["config_path", "task_name", "folder_path"]
-    args = __main__.parse_args([])
+    insecure_inputs.side_effect = ["folder_path"]
+    args = __main__.parse_args(["config_path", "task_name"])
     assert args.__dict__ == {
         "configuration_path": "config_path",
         "task_name": "task_name",
@@ -36,6 +40,10 @@ def test_arg_prompts(insecure_inputs, secure_inputs):
 
 @mock.patch("getpass.getpass", create=True)
 @mock.patch("builtins.input", create=True)
+@mock.patch.dict(
+    "os.environ",
+    {},
+)
 def test_args_positionally(insecure_inputs, secure_inputs):
     args = __main__.parse_args(
         [
@@ -104,6 +112,28 @@ def test_args_overriding_env(insecure_inputs, secure_inputs):
             "fr",
         ]
     )
+    assert args.__dict__ == {
+        "configuration_path": "config_path",
+        "task_name": "task_name",
+        "base_folder_path": "folder_path",
+        "okapi_password": "okapi_password",
+        "report_language": "fr",
+    }
+
+
+@mock.patch("getpass.getpass", create=True)
+@mock.patch("builtins.input", create=True)
+@mock.patch.dict(
+    "os.environ",
+    {
+        "FOLIO_MIGRATION_TOOLS_CONFIGURATION_PATH": "config_path",
+        "FOLIO_MIGRATION_TOOLS_BASE_FOLDER_PATH": "folder_path",
+        "FOLIO_MIGRATION_TOOLS_OKAPI_PASSWORD": "okapi_password",
+        "FOLIO_MIGRATION_TOOLS_REPORT_LANGUAGE": "fr",
+    },
+)
+def test_task_name_arg_exception(insecure_inputs, secure_inputs):
+    args = __main__.parse_args(["task_name"])
     assert args.__dict__ == {
         "configuration_path": "config_path",
         "task_name": "task_name",


### PR DESCRIPTION
If both
* FOLIO_MIGRATION_TOOLS_TASK_NAME env var is **unset**
* FOLIO_MIGRATION_TOOLS_CONFIGURATION PATH is **set**

Currently, the tool assigns the first positional arg to the config path, and chokes on no task name.

 I propose in this that instead, we should just allow it to parse the arg as a task name.
 
 
 This does mean that 
 
 ```bash
python -m folio_migration_tools arg
```
Will assign ```arg``` to config_path in *other* circumstances, and to task_name only in this situation - a bit ambiguous - but I still feel this is the closest to desired behavior