### PR TITLE
Fixes Authority JSON spec refactored in version 27 of `mod-inventory-storage

### DIFF
--- a/src/folio_migration_tools/library_configuration.py
+++ b/src/folio_migration_tools/library_configuration.py
@@ -57,6 +57,10 @@ class FolioRelease(str, Enum):
     morning_glory = "morning-glory"
     nolana = "nolana"
     orchid = "orchid"
+    poppy = "poppy"
+    quesnelia = "quesnelia"
+    ramsons = "ramsons"
+    sunflower = "sunflower"
 
 
 class LibraryConfiguration(BaseModel):

--- a/src/folio_migration_tools/marc_rules_transformation/rules_mapper_authorities.py
+++ b/src/folio_migration_tools/marc_rules_transformation/rules_mapper_authorities.py
@@ -4,9 +4,9 @@ import logging
 import re
 import time
 import uuid
-import i18n
 from typing import List
 
+import i18n
 import pymarc
 from folio_uuid.folio_namespaces import FOLIONamespaces
 from folio_uuid.folio_uuid import FolioUUID
@@ -60,7 +60,7 @@ class AuthorityMapper(RulesMapperBase):
             folio_client,
             library_configuration,
             task_configuration,
-            self.get_authority_json_schema(folio_client),
+            self.get_authority_json_schema(folio_client, library_configuration),
             Conditions(folio_client, self, "auth", library_configuration.folio_release),
         )
         self.srs_recs: list = []
@@ -219,11 +219,19 @@ class AuthorityMapper(RulesMapperBase):
         """
         folio_authority["source"] = "MARC"
 
-    def get_authority_json_schema(self, folio_client: FolioClient):
+    def get_authority_json_schema(self, folio_client: FolioClient, library_configuration):
         """Fetches the JSON Schema for autorities"""
-        return folio_client.get_from_github(
-            "folio-org", "mod-inventory-storage", "/ramls/authorities/authority.json"
-        )
+        if library_configuration.folio_release.name.lower()[0] < "p":
+            schema = folio_client.get_from_github(
+                "folio-org", "mod-inventory-storage", "/ramls/authorities/authority.json"
+            )
+        else:
+            schema = folio_client.get_from_github(
+                "folio-org",
+                "mod-entities-links",
+                "/src/main/resources/swagger.api/schemas/authority-storage/authorityDto.yaml",
+            )
+        return schema
 
     def wrap_up(self):
         logging.info("Mapper wrapping up")

--- a/tests/test_rules_mapper_auth.py
+++ b/tests/test_rules_mapper_auth.py
@@ -30,7 +30,7 @@ def mapper(pytestconfig) -> AuthorityMapper:
         tenant_id=folio.tenant_id,
         okapi_username=folio.username,
         okapi_password=folio.password,
-        folio_release=FolioRelease.orchid,
+        folio_release=FolioRelease.poppy,
         library_name="Test Run Library",
         log_level_debug=False,
         iteration_identifier="I have no clue",


### PR DESCRIPTION
Closes #693 and adds support for poppy-sunflower to FolioRelease class.