### PR TITLE
Update github action dependencies

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 


### PR DESCRIPTION
Checkout V2 and Setup Python V2 are depreciating.

For our purposes, Checkout V3 and Setup Python V4 are compatible without issue - so let's just bump the versions.