### PR TITLE
Added support for proxy borrowers to loans migrator task

### DIFF
--- a/src/folio_migration_tools/circulation_helper.py
+++ b/src/folio_migration_tools/circulation_helper.py
@@ -3,10 +3,10 @@ import json
 import logging
 import re
 import time
-import i18n
 from typing import Set
 
 import httpx
+import i18n
 from folioclient import FolioClient
 from httpx import HTTPError
 
@@ -135,6 +135,8 @@ class CirculationHelper:
                 "comment": "Migrated from legacy system",
             },
         }
+        if legacy_loan.proxy_patron_barcode:
+            data.update({"proxyUserBarcode": legacy_loan.proxy_patron_barcode})
         path = "/circulation/check-out-by-barcode"
         url = f"{self.folio_client.okapi_url}{path}"
         try:

--- a/src/folio_migration_tools/circulation_helper.py
+++ b/src/folio_migration_tools/circulation_helper.py
@@ -248,7 +248,7 @@ class CirculationHelper:
         folio_client: FolioClient, legacy_request: LegacyRequest, migration_report: MigrationReport
     ):
         try:
-            path = "/circulation/httpx"
+            path = "/circulation/requests"
             url = f"{folio_client.okapi_url}{path}"
             data = legacy_request.serialize()
             data["requestProcessingParameters"] = {

--- a/src/folio_migration_tools/transaction_migration/legacy_loan.py
+++ b/src/folio_migration_tools/transaction_migration/legacy_loan.py
@@ -30,7 +30,7 @@ class LegacyLoan(object):
             "next_item_status",
             "service_point_id",
         ]
-        optional_headers = ["service_point_id"]
+        optional_headers = ["service_point_id", "proxy_patron_barcode"]
         legal_statuses = [
             "",
             "Aged to lost",
@@ -86,6 +86,7 @@ class LegacyLoan(object):
         # good to go, set properties
         self.item_barcode: str = legacy_loan_dict["item_barcode"].strip()
         self.patron_barcode: str = legacy_loan_dict["patron_barcode"].strip()
+        self.proxy_patron_barcode: str = legacy_loan_dict.get("proxy_patron_barcode", "")
         self.due_date: datetime = temp_date_due
         self.out_date: datetime = temp_date_out
         self.correct_for_1_day_loans()

--- a/tests/test_loans_migrator.py
+++ b/tests/test_loans_migrator.py
@@ -94,3 +94,45 @@ def test_load_and_validate_legacy_loans_set_centrally():
             mock_migrator, reader, "Set on file or config"
         )
         assert a[0].service_point_id == "Set on file or config"
+
+
+def test_load_and_validate_legacy_loans_with_proxy():
+    with StringIO() as csvfile:
+        csvfile.seek(0)
+        fieldnames = [
+            "item_barcode",
+            "patron_barcode",
+            "proxy_patron_barcode",
+            "due_date",
+            "out_date",
+            "renewal_count",
+            "next_item_status",
+        ]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "item_barcode": "i_barcode",
+                "patron_barcode": "p_barcode",
+                "proxy_patron_barcode": "prox_barcode",
+                "due_date": "2020-10-12T02:02:02",
+                "out_date": "2020-09-12T02:02:02",
+                "renewal_count": "1",
+                "next_item_status": "",
+            }
+        )
+        csvfile.seek(0)
+        reader = csv.DictReader(csvfile)
+
+        mock_library_conf = Mock(spec=LibraryConfiguration)
+        mock_library_conf.okapi_url = "http://okapi_url"
+        mock_library_conf.tenant_id = ""
+        mock_library_conf.okapi_username = ""
+        mock_library_conf.okapi_password = ""  # noqa: 105
+        mock_migrator = Mock(spec=LoansMigrator)
+        mock_migrator.migration_report = MigrationReport()
+        mock_migrator.tenant_timezone = ZoneInfo("UTC")
+        a = LoansMigrator.load_and_validate_legacy_loans(
+            mock_migrator, reader, "Set on file or config"
+        )
+        assert a[0].proxy_patron_barcode == "prox_barcode"


### PR DESCRIPTION
Adds support for a new `proxy_patron_barcode` column in the legacy loans data file, validates that barcode against transformed patron data, if present, and adds it to the `check-out-by-barcode` JSON object as `"proxyUserBarcode"`.

Closes #709