### PR TITLE
Introducing ecs tenant id handling 

### DIFF
--- a/src/folio_migration_tools/library_configuration.py
+++ b/src/folio_migration_tools/library_configuration.py
@@ -66,6 +66,16 @@ class FolioRelease(str, Enum):
 class LibraryConfiguration(BaseModel):
     okapi_url: str
     tenant_id: str
+    ecs_tenant_id: Annotated[
+        str,
+        Field(
+            title="ECS tenant ID",
+            description=(
+                "For use in ECS environments when the configuration file is meant to target a ",
+                "data tenant. Set to the tenant ID of the data tenant."
+            )
+        )
+    ] = ""
     okapi_username: str
     okapi_password: str
     base_folder: DirectoryPath = Field(
@@ -91,4 +101,7 @@ class LibraryConfiguration(BaseModel):
         )
     )
     iteration_identifier: str
-    add_time_stamp_to_file_names: Optional[bool] = False
+    add_time_stamp_to_file_names: Annotated[
+        bool, 
+        Field(title="Add time stamp to file names")
+    ] = False

--- a/src/folio_migration_tools/migration_tasks/migration_task_base.py
+++ b/src/folio_migration_tools/migration_tasks/migration_task_base.py
@@ -14,6 +14,7 @@ from folioclient import FolioClient
 from genericpath import isfile
 
 from folio_migration_tools import library_configuration
+from folio_migration_tools import task_configuration
 from folio_migration_tools.custom_exceptions import TransformationProcessError
 from folio_migration_tools.custom_exceptions import TransformationRecordFailedError
 from folio_migration_tools.extradata_writer import ExtradataWriter
@@ -35,7 +36,7 @@ class MigrationTaskBase:
     def __init__(
         self,
         library_configuration: library_configuration.LibraryConfiguration,
-        task_configuration,
+        task_configuration: task_configuration.AbstractTaskConfiguration,
         use_logging: bool = True,
     ):
         logging.info("MigrationTaskBase init")
@@ -48,6 +49,11 @@ class MigrationTaskBase:
             library_configuration.okapi_username,
             library_configuration.okapi_password,
         )
+        self.ecs_tenant_id = task_configuration.ecs_tenant_id or library_configuration.ecs_tenant_id
+        self.ecs_tenant_header = {
+            "x-okapi-tenant": self.ecs_tenant_id
+        } if self.ecs_tenant_id else {}
+        self.folio_client.okapi_headers.update(self.ecs_tenant_header)
         self.folder_structure: FolderStructure = FolderStructure(
             library_configuration.base_folder,
             self.get_object_type(),

--- a/src/folio_migration_tools/task_configuration.py
+++ b/src/folio_migration_tools/task_configuration.py
@@ -1,5 +1,8 @@
+from typing import Annotated
+
 from humps import camelize
 from pydantic import BaseModel
+from pydantic import Field
 
 
 def to_camel(string):
@@ -7,6 +10,18 @@ def to_camel(string):
 
 
 class AbstractTaskConfiguration(BaseModel):
+    name: str
+    ecs_tenant_id: Annotated[
+        str,
+        Field(
+            title="ECS tenant ID",
+            description=(
+                "The tenant ID to use when making requests to FOLIO APIs for this task, if ",
+                "different from library configuration"
+            )
+        )
+    ] = ""
+
     class Config:
         alias_generator = to_camel
         allow_population_by_field_name = True


### PR DESCRIPTION
This change allows specification of an ECS data tenant ID to use in place of the the `tenantId` value specified in the`libraryInformation` section of the project configuration. This allows projects to contain tasks targeting different data tenants in an ECS-enabled system (eg. transform a set of shared MARC bibs against the central tenant, but transform a set of holdings and item records against separate member tenants per task). The `tenantId` value is used if no `ecsTenantId` is specified and is always used when initially authenticating to FOLIO.