### PR TITLE
Fixing dedupe_list_of_dict method on HoldingsStatementsParser does not preserve item order 

### DIFF
--- a/src/folio_migration_tools/marc_rules_transformation/holdings_statementsparser.py
+++ b/src/folio_migration_tools/marc_rules_transformation/holdings_statementsparser.py
@@ -232,7 +232,7 @@ class HoldingsStatementsParser:
 
     @staticmethod
     def dedupe_list_of_dict(list_of_dict):
-        return [dict(t) for t in {tuple(d.items()) for d in list_of_dict}]
+        return [dict(t) for t in {tuple(d.items()): None for d in list_of_dict}]
 
     @staticmethod
     def g_m(m: int):


### PR DESCRIPTION
Fixes #733