### PR TITLE
713 loans migrator empty renewal count issue

### DIFF
--- a/src/folio_migration_tools/transaction_migration/legacy_loan.py
+++ b/src/folio_migration_tools/transaction_migration/legacy_loan.py
@@ -91,8 +91,7 @@ class LegacyLoan(object):
         self.out_date: datetime = temp_date_out
         self.correct_for_1_day_loans()
         self.make_utc()
-        self.renewal_count = 0
-        self.set_renewal_count(legacy_loan_dict)
+        self.renewal_count = self.set_renewal_count(legacy_loan_dict)
         self.next_item_status = legacy_loan_dict.get("next_item_status", "").strip()
         if self.next_item_status not in legal_statuses:
             self.errors.append(("Not an allowed status", self.next_item_status))
@@ -102,16 +101,17 @@ class LegacyLoan(object):
             else fallback_service_point_id
         )
 
-    def set_renewal_count(self, loan: dict):
+    def set_renewal_count(self, loan: dict) -> int:
         if "renewal_count" in loan:
             renewal_count = loan["renewal_count"]
             try:
-                self.renewal_count = int(renewal_count)
+                return int(renewal_count)
             except ValueError:
                 self.report(
                     f"Unresolvable {renewal_count=} was replaced with 0.")
         else:
             self.report(f"Missing renewal count was replaced with 0.")
+        return 0
 
     def correct_for_1_day_loans(self):
         try:

--- a/src/folio_migration_tools/transaction_migration/legacy_loan.py
+++ b/src/folio_migration_tools/transaction_migration/legacy_loan.py
@@ -91,7 +91,8 @@ class LegacyLoan(object):
         self.out_date: datetime = temp_date_out
         self.correct_for_1_day_loans()
         self.make_utc()
-        self.renewal_count = int(legacy_loan_dict["renewal_count"])
+        self.renewal_count = 0
+        self.set_renewal_count(legacy_loan_dict)
         self.next_item_status = legacy_loan_dict.get("next_item_status", "").strip()
         if self.next_item_status not in legal_statuses:
             self.errors.append(("Not an allowed status", self.next_item_status))
@@ -100,6 +101,17 @@ class LegacyLoan(object):
             if legacy_loan_dict.get("service_point_id", "")
             else fallback_service_point_id
         )
+
+    def set_renewal_count(self, loan: dict):
+        if "renewal_count" in loan:
+            renewal_count = loan["renewal_count"]
+            try:
+                self.renewal_count = int(renewal_count)
+            except ValueError:
+                self.report(
+                    f"Unresolvable {renewal_count=} was replaced with 0.")
+        else:
+            self.report(f"Missing renewal count was replaced with 0.")
 
     def correct_for_1_day_loans(self):
         try:

--- a/tests/test_legacy_loan.py
+++ b/tests/test_legacy_loan.py
@@ -163,12 +163,28 @@ def test_init_tz_5():  # Test dates with(out) DST
     )
 
 
+def test_init_renewal_count_is_missing():
+    loan_dict = {
+        "item_barcode": "the barcode with trailing space ",
+        "patron_barcode": " the barcode with leading space",
+        "due_date": "20220113 16:00",
+        "out_date": "20220113 14:00",
+        "next_item_status": "Checked out",
+    }
+    tenant_timezone = ZoneInfo("UTC")
+    migration_report = MigrationReport()
+    legacy_loan = LegacyLoan(
+        loan_dict, "", migration_report, tenant_timezone)
+    assert legacy_loan.renewal_count == 0
+
+
 def test_init_renewal_count_is_empty():
     loan_dict = {
         "item_barcode": "the barcode with trailing space ",
         "patron_barcode": " the barcode with leading space",
         "due_date": "20220113 16:00",
         "out_date": "20220113 14:00",
+        "renewal_count": "",
         "next_item_status": "Checked out",
     }
     tenant_timezone = ZoneInfo("UTC")

--- a/tests/test_legacy_loan.py
+++ b/tests/test_legacy_loan.py
@@ -161,3 +161,34 @@ def test_init_tz_5():  # Test dates with(out) DST
         "Provided out_date is not UTC, setting tzinfo to tenant timezone (America/Chicago)"
         in migration_report.report["Details"]
     )
+
+
+def test_init_renewal_count_is_empty():
+    loan_dict = {
+        "item_barcode": "the barcode with trailing space ",
+        "patron_barcode": " the barcode with leading space",
+        "due_date": "20220113 16:00",
+        "out_date": "20220113 14:00",
+        "next_item_status": "Checked out",
+    }
+    tenant_timezone = ZoneInfo("UTC")
+    migration_report = MigrationReport()
+    legacy_loan = LegacyLoan(
+        loan_dict, "", migration_report, tenant_timezone)
+    assert legacy_loan.renewal_count == 0
+
+
+def test_init_renewal_count_is_unresolvable():
+    loan_dict = {
+        "item_barcode": "the barcode with trailing space ",
+        "patron_barcode": " the barcode with leading space",
+        "due_date": "20220113 16:00",
+        "out_date": "20220113 14:00",
+        "renewal_count": "abc",
+        "next_item_status": "Checked out",
+    }
+    tenant_timezone = ZoneInfo("UTC")
+    migration_report = MigrationReport()
+    legacy_loan = LegacyLoan(
+        loan_dict, "", migration_report, tenant_timezone)
+    assert legacy_loan.renewal_count == 0


### PR DESCRIPTION
## Purpose
Fixes [#713](https://github.com/FOLIO-FSE/folio_migration_tools/issues/713)

## Changes Made in this PR
Added a new function set_renewal_count(loan: dict) that returns 0 if the key "renewal_count" is missing in the loan dictionary, or its value is empty or not a string containing a number, otherwise it returns an integer from its value. Corresponding test cases have been added.

## Code Review Specifics
This just needs approval.

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [x] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## Warning Checklist
<!-- These items warn others about potential issues. Check any that apply. -->
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
Migrate loans with missing, empty or unresolvable values of renewal count.
