### PR TITLE
Fix file path references in failed records clean-up

### DIFF
--- a/src/folio_migration_tools/migration_tasks/batch_poster.py
+++ b/src/folio_migration_tools/migration_tasks/batch_poster.py
@@ -188,9 +188,10 @@ class BatchPoster(MigrationTaskBase):
 
                 except Exception as ee:
                     if "idx" in locals() and self.task_configuration.files[idx:]:
-                        for file in self.task_configuration.files[idx:]:
+                        for file_def in self.task_configuration.files[idx:]:
+                            path = self.folder_structure.results_folder / file_def.file_name
                             try:
-                                with open(file, "r") as failed_file:
+                                with open(path, "r") as failed_file:
                                     failed_file.seek(self.processed)
                                     failed_recs_file.write(failed_file.read())
                                     self.processed = 0


### PR DESCRIPTION
## Purpose
<!-- Why are you making this change?  Provide the reviewer and future readers the cause that gave rise to this pull request. Include enough detail for a developer from another team to reconstruct the necessary context merely by reading this section.

You can link to an Issue by saying something like "Fixes #1" -->
Fix a bug introduced in #833 around writing all remaining records out to the failed records file when an exception occurs during a BatchPoster task.
## Changes Made in this PR
<!-- How does this change fulfill the purpose? It's best to talk high-level strategy and avoid restating the commit history. The goal is not only to explain what you did, but help other developers work with your solution in the future. -->
The original implementation missed constructing a valid path object for the remaining file definitions. This change fixes that.
## Code Review Specifics
<!-- Is this change trivial, or this project still in MVP just push along mode? Or is there an area you'd really like a thorough review? E.g:
- This just needs approval
- Read the code, make suggestions
- Fire it up and make sure it works
-
-->
- Minor change to existing functionality to fix a bug
## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [x] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [ ] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## Warning Checklist
<!-- These items warn others about potential issues. Check any that apply. -->
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
<!-- Provide the steps necessary to verify the changes made to resolve the ticket acceptance criteria -->

## Open Questions
<!-- *OPTIONAL*
  - [ ] Use GitHub checklists to prompt discussion around questions you may have with your approach. When solved, check the box and explain the answer.
-->

## Learn Anything Cool?
<!-- *OPTIONAL* Crafting a solution sometimes requires a lot of research. Don't let all that hard work go to waste! Use this opportunity to share what you learned. Add links to blog posts, patterns, libraries, and other resources used to solve this problem. -->
