### PR TITLE
346 Two test cases for condition_remove_prefix_by_indicator

### DIFF
--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -249,3 +249,31 @@ def test_condition_set_subject_source_id_by_code_no_match():
         ).get('2'))
     assert res_error.type is TransformationProcessError
     assert res_error.value.message.startswith("Subject source not found for MeSH")
+
+
+def test_condition_remove_prefix_by_indicator():
+    mock = Mock(spec=Conditions)
+    marc_fields = [
+        Field(
+            tag="100",
+            indicators=["1", "0"],
+            subfields=[
+                Subfield(code="a", value="Subject 1")
+            ],
+        ),
+        Field(
+            tag="200",
+            indicators=["1", "5"],
+            subfields=[
+                Subfield(code="b", value="Subject 2")
+            ],
+        ),
+    ]
+    res100 = Conditions.condition_remove_prefix_by_indicator(
+        mock, "", "some value: /", {}, marc_fields[0]
+    )
+    assert res100 == "some value"
+    res200 = Conditions.condition_remove_prefix_by_indicator(
+        mock, "", "some value: /", {}, marc_fields[1]
+    )
+    assert res200 == "value"


### PR DESCRIPTION
## Purpose
Fixes [#346](https://github.com/FOLIO-FSE/folio_migration_tools/issues/346)

## Changes Made in this PR
Added two test cases for the condition_remove_prefix_by_indicator method to check marc_field.indicator2 in the range of 1-9 and outside of this range.

## Code Review Specifics
Unfortunately, I was unable to complete all the conditions in the check list below because `nox -rs safety` is causing an error `poetry: The requested command export does not exist.`, and `nox -rs tests` with tenant and credentials is causing errors
```
ModuleNotFoundError: No module named 'tzdata'
zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key UTC'. 
```
However, running the test separately with `pytest test_conditions.py` does not result in errors in the written code, so I hope the task of writing the test itself to be completed.

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [ ] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [ ] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## How to Verify
```bash
cd tests
pytest test_conditions.py
```
