### PR TITLE
578 Add annotation to the Task configuration entries for BatchPoster

### DIFF
--- a/src/folio_migration_tools/migration_tasks/batch_poster.py
+++ b/src/folio_migration_tools/migration_tasks/batch_poster.py
@@ -50,46 +50,84 @@ class BatchPoster(MigrationTaskBase):
     """
 
     class TaskConfiguration(AbstractTaskConfiguration):
-        name: str
-        migration_task_type: str
-        object_type: str
-        files: List[FileDefinition]
-        batch_size: int
+        name: Annotated[
+            str,
+            Field(
+                title="Task name",
+                description="The name of the task",
+            ),
+        ]
+        migration_task_type: Annotated[
+            str,
+            Field(
+                title="Migration task type",
+                description="The type of migration task",
+            ),
+        ]
+        object_type: Annotated[
+            str,
+            Field(
+                title="Object type",
+                description=(
+                    "The type of object being migrated"
+                    "Examples of possible values: "
+                    "'Extradata', 'SRS', Instances', 'Holdings', 'Items'"
+                ),
+            ),
+        ]
+        files: Annotated[
+            List[FileDefinition],
+            Field(
+                title="List of files",
+                description="List of files to be processed",
+            ),
+        ]
+        batch_size: Annotated[
+            int,
+            Field(
+                title="Batch size",
+                description="The batch size for processing files",
+            ),
+        ]
         rerun_failed_records: Annotated[
             bool,
             Field(
+                title="Rerun failed records",
                 description=(
-                    "Toggles whether or not BatchPoster should try to rerun failed batches or "
-                    "just leave the failing records on disk."
-                )
+                    "Toggles whether or not BatchPoster should try to rerun "
+                    "failed batches or just leave the failing records on disk."
+                ),
             ),
         ] = True
         use_safe_inventory_endpoints: Annotated[
             bool,
             Field(
+                title="Use safe inventory endpoints",
                 description=(
-                    "Toggles the use of the safe/unsafe Inventory storage endpoints. "
-                    "Unsafe circumvents the Optimistic locking in FOLIO. Defaults to "
-                    "True (using the 'safe' options)"
-                )
+                    "Toggles the use of the safe/unsafe Inventory storage "
+                    "endpoints. Unsafe circumvents the Optimistic locking "
+                    "in FOLIO. Defaults to True (using the 'safe' options)"
+                ),
             ),
         ] = True
         extradata_endpoints: Annotated[
             dict,
             Field(
+                title="Extradata endpoints",
                 description=(
                     "A dictionary of extradata endpoints. "
                     "The key is the object type and the value is the endpoint"
-                )
+                ),
             ),
         ] = {}
         upsert: Annotated[
             bool,
             Field(
+                title="Upsert",
                 description=(
-                    "Toggles whether or not to use the upsert feature of the Inventory storage "
-                    "endpoints. Defaults to False"
-                )
+                    "Toggles whether or not to use the upsert feature "
+                    "of the Inventory storage endpoints. Defaults to False"
+                ),
             ),
         ] = False
 

--- a/src/folio_migration_tools/task_configuration.py
+++ b/src/folio_migration_tools/task_configuration.py
@@ -16,8 +16,8 @@ class AbstractTaskConfiguration(BaseModel):
         Field(
             title="ECS tenant ID",
             description=(
-                "The tenant ID to use when making requests to FOLIO APIs for this task, if ",
-                "different from library configuration",
+                "The tenant ID to use when making requests to FOLIO APIs "
+                "for this task, if different from library configuration",
             ),
         ),
     ] = ""


### PR DESCRIPTION
## Purpose
Fixes [#578](https://github.com/FOLIO-FSE/folio_migration_tools/issues/578)

## Changes Made in this PR
Annotations to the Task configuration entries for BatchPoster has been added

## Code Review Specifics
This just needs approval

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [ ] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [ ] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## Warning Checklist
<!-- These items warn others about potential issues. Check any that apply. -->
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
```bash
cd tests
pytest test_batch_poster.py
```
