### PR TITLE
Poetry export plugin has been added to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,6 @@ ipykernel = "^6.29.5"
 
 [tool.poetry.extras]
 docs = ["m2r", "sphinx", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "toml"]
+
+[tool.poetry.requires-plugins]
+poetry-plugin-export = ">=1.8"


### PR DESCRIPTION
## Purpose
`nox -rs safety` doesn't run without installing export plugin for poetry.

![nox-safety](https://github.com/user-attachments/assets/2a4077ed-9516-4f05-8f0a-992e340c62bb)

## Changes Made in this PR
Command for installing export plugin has beed added to pyproject.toml.

## Code Review Specifics
- Minor change, needs approval

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [x] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## Warning Checklist
<!-- These items warn others about potential issues. Check any that apply. -->
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
Clear install poetry then run `nox -rs safety`
