### PR TITLE
588 Add annotations to the Task configuration entries for ReservesMigrator

### DIFF
--- a/src/folio_migration_tools/migration_tasks/reserves_migrator.py
+++ b/src/folio_migration_tools/migration_tasks/reserves_migrator.py
@@ -4,8 +4,9 @@ import logging
 import sys
 import time
 import traceback
-from typing import Dict
+from typing import Dict, Annotated
 from urllib.error import HTTPError
+from pydantic import Field
 
 import httpx
 import i18n
@@ -25,9 +26,30 @@ from folio_migration_tools.transaction_migration.legacy_reserve import LegacyRes
 
 class ReservesMigrator(MigrationTaskBase):
     class TaskConfiguration(AbstractTaskConfiguration):
-        name: str
-        migration_task_type: str
-        course_reserve_file_path: FileDefinition
+        name: Annotated[
+            str,
+            Field(
+                title="Migration task name",
+                description=(
+                    "Name of this migration task. The name is being used to call the specific "
+                    "task, and to distinguish tasks of similar types"
+                ),
+            ),
+        ]
+        migration_task_type: Annotated[
+            str,
+            Field(
+                title="Migration task type",
+                description="The type of migration task you want to perform",
+            ),
+        ]
+        course_reserve_file_path: Annotated[
+            FileDefinition,
+            Field(
+                title="Course reserve file path",
+                description="Path to the file with course reserves",
+            ),
+        ]
 
     @staticmethod
     def get_object_type() -> FOLIONamespaces:


### PR DESCRIPTION
## Purpose
Fixes [#588](https://github.com/FOLIO-FSE/folio_migration_tools/issues/588)

## Changes Made in this PR
Annotations to the Task configuration entries for ReservesMigrator has been added

## Code Review Specifics
- Minor changes. This just needs approval.

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [x] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [ ] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## Warning Checklist
<!-- These items warn others about potential issues. Check any that apply. -->
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
```bush
poetry run pytest tests/test_reserves_migrator.py
```