### PR TITLE
Refactoring validate_po_number method in order_mapper

### DIFF
--- a/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
@@ -25,7 +25,6 @@ from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
 
 
 class CompositeOrderMapper(MappingFileMapperBase):
-    VALID_PO_NUMBER_CHARACTERS = r"[A-Za-z0-9]"
 
     def __init__(
         self,
@@ -385,7 +384,7 @@ class CompositeOrderMapper(MappingFileMapperBase):
             index_or_id: str,
             po_number: str,
     ):
-        if re.sub(self.VALID_PO_NUMBER_CHARACTERS, "", po_number):
+        if not self.is_valid_po_number(po_number):
             self.migration_report.add(
                 "PurchaseOrderVendorLinking",
                 i18n.t("RECORD FAILED: PO number has invalid character(s)"),
@@ -395,6 +394,11 @@ class CompositeOrderMapper(MappingFileMapperBase):
                 "Purchase Order number has invalid character(s)",
                 po_number,
             )
+
+    @staticmethod
+    def is_valid_po_number(po_number: str) -> bool:
+        valid_po_number_characters = r"[A-Za-z0-9]"
+        return re.sub(valid_po_number_characters, "", po_number) == ""
 
     def get_matching_record_from_folio(
         self,

--- a/tests/test_orders_mapper.py
+++ b/tests/test_orders_mapper.py
@@ -578,3 +578,12 @@ def test_perform_additional_mapping_instance_uuid_no_match(mapper):
     folio_po = mapper.perform_additional_mapping("1", folio_po)
 
     assert "instanceId" not in folio_po["compositePoLines"][0]
+
+
+def test_is_valid_po_number():
+    assert CompositeOrderMapper.is_valid_po_number("Spam123")
+    assert not CompositeOrderMapper.is_valid_po_number("o 124")
+    assert not CompositeOrderMapper.is_valid_po_number("o-124")
+    assert not CompositeOrderMapper.is_valid_po_number("o_124")
+    assert not CompositeOrderMapper.is_valid_po_number("o.124")
+    assert not CompositeOrderMapper.is_valid_po_number("o/124")


### PR DESCRIPTION
## Purpose
Refactoring to fulfill @bltravis [comment](https://github.com/FOLIO-FSE/folio_migration_tools/pull/825#pullrequestreview-2612562784) to [PR](https://github.com/FOLIO-FSE/folio_migration_tools/pull/825).

## Changes Made in this PR
Global variable has been deleted new static function `is_valid_po_number()` and test for it have been added.

## Code Review Specifics
- This just needs approval

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [x] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## How to Verify
```bash
poetry run pytest ./tests/test_orders_mapper.py
```
