### PR TITLE
349 Increase test coverage in legacy_reserve.py (rebased)

### DIFF
--- a/src/folio_migration_tools/transaction_migration/legacy_reserve.py
+++ b/src/folio_migration_tools/transaction_migration/legacy_reserve.py
@@ -1,7 +1,5 @@
 import uuid
-from typing import Dict
-from typing import List
-from typing import Tuple
+from typing import Dict, List, Tuple
 
 from folio_uuid.folio_namespaces import FOLIONamespaces
 from folio_uuid.folio_uuid import FolioUUID
@@ -17,9 +15,9 @@ class LegacyReserve(object):
         for h in correct_headers:
             if h not in legacy_request_dict:
                 raise TransformationProcessError(
-                    int,
+                    row,
                     "Missing header in file. The following are required:",
-                    ",".join(correct_headers),
+                    ", ".join(correct_headers),
                 )
         self.errors: List[Tuple[str, str]] = [
             ("Missing properties in legacy data", prop)

--- a/tests/test_legacy_reserve.py
+++ b/tests/test_legacy_reserve.py
@@ -1,0 +1,43 @@
+import pytest
+
+from folioclient import FolioClient
+from folio_migration_tools.transaction_migration.legacy_reserve import LegacyReserve
+from folio_migration_tools.test_infrastructure import mocked_classes
+from folio_migration_tools.custom_exceptions import TransformationProcessError
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mocked_folio_client(pytestconfig):
+    return mocked_classes.mocked_folio_client()
+
+
+def test_to_dict_happy_path(mocked_folio_client: FolioClient):
+    legacy_request_dict = {
+        "legacy_identifier": "123456",
+        "item_barcode": "78901234"
+    }
+    legacy_reserve = LegacyReserve(legacy_request_dict, mocked_folio_client)
+
+    expected_output = {
+        "courseListingId": legacy_reserve.course_listing_id,
+        "copiedItem": {"barcode": "78901234"},
+        "id": legacy_reserve.id
+    }
+    assert legacy_reserve.to_dict() == expected_output
+
+
+def test_to_dict_missing_keys(mocked_folio_client: FolioClient):
+    legacy_request_dict = {
+        "some_other_header": "spam",
+        "item_barcode": "78901234"
+    }
+    with pytest.raises(TransformationProcessError) as exc_info:
+        _legacy_reserve = LegacyReserve(legacy_request_dict, mocked_folio_client)
+
+    expected_output = (
+        "Critical Process issue. Check configuration, mapping files and reference data"
+        "\t0"
+        "\tMissing header in file. The following are required:"
+        "\tlegacy_identifier, item_barcode"
+    )
+    assert str(exc_info.value) == expected_output


### PR DESCRIPTION
## Purpose
Fixes [#349](https://github.com/FOLIO-FSE/folio_migration_tools/issues/349)

## Changes Made in this PR
Tests for legacy_reserve.py have been added. Minor error in passing parameters for TransformationProcessError fixed.

## Code Review Specifics
- Read the code, make suggestions

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [x] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## How to Verify
```bash
poetry run pytest -v tests/test_legacy_reserve.py
```