### PR TITLE
Adding set_version methods to BatchPoster for to support inventory upsert

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folio_migration_tools"
-version = "1.9.0rc3"
+version = "1.9.0rc4"
 description =  "A tool allowing you to migrate data from legacy ILS:s (Library systems) into FOLIO LSP"
 authors = [
 	{name = "Theodor Tolstoy", email = "github.teddes@tolstoy.se"},
@@ -77,6 +77,7 @@ pandas = "^1.5.3"
 types-requests = "^2.28.11.17"
 types-python-dateutil = "^2.8.19.11"
 ipykernel = "^6.29.5"
+pytest-asyncio = "^0.23.0"
 
 [tool.poetry.extras]
 docs = ["m2r", "sphinx", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "toml"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 log_cli = 0
 log_cli_level = INFO
+asyncio_mode = auto
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     serial

--- a/src/folio_migration_tools/migration_tasks/batch_poster.py
+++ b/src/folio_migration_tools/migration_tasks/batch_poster.py
@@ -302,8 +302,9 @@ class BatchPoster(MigrationTaskBase):
                     for record in response_json[object_type]:
                         updates[record["id"]] = {
                             "_version": record["_version"],
-                            "status": record["status"],
                         }
+                        if "status" in record:
+                            updates[record["id"]]["status"] = record["status"]
                 else:
                     logging.error(
                         "Failed to fetch current records. HTTP %s\t%s",

--- a/tests/test_batch_poster.py
+++ b/tests/test_batch_poster.py
@@ -1,9 +1,12 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, AsyncMock, patch, create_autospec
 
 from folio_uuid.folio_namespaces import FOLIONamespaces
+from folioclient import FolioClient
 
 from folio_migration_tools.migration_tasks import batch_poster
 from folio_migration_tools.migration_tasks.batch_poster import BatchPoster
+import pytest
+import httpx
 
 
 def test_get_object_type():
@@ -19,7 +22,7 @@ def test_get_unsafe_and_safe_endpoints():
         batch_poster.get_api_info("Instances")["api_endpoint"]
         == "/instance-storage/batch/synchronous"
     )
-    assert(
+    assert (
         batch_poster.get_api_info("ShadowInstances", False)["api_endpoint"]
         == "/instance-storage/batch/synchronous-unsafe"
     )
@@ -39,11 +42,16 @@ def test_get_unsafe_and_safe_endpoints():
         batch_poster.get_api_info("Items", False)["api_endpoint"]
         == "/item-storage/batch/synchronous-unsafe"
     )
-    assert batch_poster.get_api_info("Items")["api_endpoint"] == "/item-storage/batch/synchronous"
+    assert (
+        batch_poster.get_api_info("Items")["api_endpoint"]
+        == "/item-storage/batch/synchronous"
+    )
 
 
 def test_get_extradata_endpoint_interface_credential():
-    extradata = 'interfaceCredential\t{"interfaceId": "7e131c38-5384-44ed-9f4a-da6ca2f36498"}'
+    extradata = (
+        'interfaceCredential\t{"interfaceId": "7e131c38-5384-44ed-9f4a-da6ca2f36498"}'
+    )
     (object_name, data) = extradata.split("\t")
 
     batch_poster_task = Mock(spec=BatchPoster)
@@ -84,3 +92,68 @@ def test_set_consortium_source():
     BatchPoster.set_consortium_source(json_rec_folio)
     assert json_rec_marc["source"] == "CONSORTIUM-MARC"
     assert json_rec_folio["source"] == "CONSORTIUM-FOLIO"
+
+
+@pytest.mark.asyncio
+async def test_set_version_async():
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "instances": [
+            {"id": "record1", "_version": 1, "status": {"name": "Available"}},
+            {"id": "record2", "_version": 2, "status": {"name": "Checked out"}},
+        ]
+    }
+
+    # Mock the httpx.AsyncClient.get method
+    with patch("httpx.AsyncClient.get", return_value=mock_response) as mock_get:
+        # Create an instance of the BatchPoster class
+        batch_poster = create_autospec(spec=BatchPoster)
+        batch_poster.folio_client = Mock(spec=FolioClient)
+        batch_poster.folio_client.okapi_headers = {"x-okapi-token": "token"}
+        batch_poster.folio_client.okapi_url = "http://folio-snapshot-okapi.dev.folio.org"
+        batch_poster.set_version_async = Mock(wraps=BatchPoster.set_version_async)
+
+        # Define test inputs
+        batch = [{"id": "record1"}, {"id": "record2"}]
+        query_api = "/instance-storage/instances"
+        object_type = "instances"
+
+        # Act
+        await batch_poster.set_version_async(batch_poster, batch, query_api, object_type)
+
+        # Assert
+        assert batch[0]["_version"] == 1
+        assert batch[1]["_version"] == 2
+        assert batch[0]["status"]["name"] == "Available"
+        assert batch[1]["status"]["name"] == "Checked out"
+        mock_get.assert_called_once_with(
+            query_api,
+            params={
+                "query": "id==(record1 OR record2)",
+                "limit": 90,
+            },
+            headers=batch_poster.folio_client.okapi_headers,
+        )
+
+
+def test_set_version():
+    # Mock the asynchronous function
+    with patch("folio_migration_tools.migration_tasks.batch_poster.BatchPoster.set_version_async") as mock_async:
+        mock_async.return_value = None  # Simulate no return value for the async function
+
+        # Create an instance of the BatchPoster class
+        batch_poster = create_autospec(spec=BatchPoster)
+        batch_poster.set_version_async = mock_async
+        batch_poster.set_version = Mock(wraps=BatchPoster.set_version)
+
+        # Define test inputs
+        batch = [{"id": "record1"}, {"id": "record2"}]
+        query_api = "/instance-storage/instances"
+        object_type = "instances"
+
+        # Act
+        batch_poster.set_version(batch_poster, batch, query_api, object_type)
+
+        # Assert
+        mock_async.assert_called_once_with(batch, query_api, object_type)


### PR DESCRIPTION
## Purpose
<!-- Why are you making this change?  Provide the reviewer and future readers the cause that gave rise to this pull request. Include enough detail for a developer from another team to reconstruct the necessary context merely by reading this section.

You can link to an Issue by saying something like "Fixes #1" -->
Add support for fetching current _version (and status for items) when using upsert in BatchPoster

## Changes Made in this PR
<!-- How does this change fulfill the purpose? It's best to talk high-level strategy and avoid restating the commit history. The goal is not only to explain what you did, but help other developers work with your solution in the future. -->
* Added an async method to fetch records by id and update the `_version` attribute of transformed records before posting with upsert.
* Added tests for the new method and the synchronous wrapper method.

## Code Review Specifics
<!-- Is this change trivial, or this project still in MVP just push along mode? Or is there an area you'd really like a thorough review? E.g:
- This just needs approval
- Read the code, make suggestions
- Fire it up and make sure it works
-
-->

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [ ] Ran `nox -rs safety`.
- [x] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## Warning Checklist
<!-- These items warn others about potential issues. Check any that apply. -->
- [x] New dependencies added
- [ ] Includes breaking changes

## How to Verify
<!-- Provide the steps necessary to verify the changes made to resolve the ticket acceptance criteria -->
Run an Inventory BatchPoster task with upsert=true

## Open Questions
<!-- *OPTIONAL*
  - [ ] Use GitHub checklists to prompt discussion around questions you may have with your approach. When solved, check the box and explain the answer.
-->

## Learn Anything Cool?
<!-- *OPTIONAL* Crafting a solution sometimes requires a lot of research. Don't let all that hard work go to waste! Use this opportunity to share what you learned. Add links to blog posts, patterns, libraries, and other resources used to solve this problem. -->
* You can fetch 90 inventory records via storage APIs at a time by using an `id==(<id> OR <otherId>...)` query