### PR TITLE
Log invalid invalid authorityId mapping as a record-level data issue and modify the entity mapping to allow transformation ton continue and produce valid records

### DIFF
--- a/src/folio_migration_tools/marc_rules_transformation/rules_mapper_base.py
+++ b/src/folio_migration_tools/marc_rules_transformation/rules_mapper_base.py
@@ -559,6 +559,16 @@ class RulesMapperBase(MapperBase):
             if k == "authorityId" and (legacy_subfield_9 := marc_field.get("9")):
                 marc_field.add_subfield("0", legacy_subfield_9)
                 marc_field.delete_subfield("9")
+            if k == "authorityId" and (entity_subfields := entity_mapping.get("subfield", [])):
+                for subfield in entity_subfields:
+                    if subfield != "9":
+                        Helper.log_data_issue(
+                            index_or_legacy_id,
+                            f"authorityId mapping from ${subfield} is not supported. Data Import will fail. "
+                            "Use only $9 for authority id mapping in MARC-to-Instance mapping rules.",
+                            marc_field,
+                        )
+                        entity_mapping["subfield"] = ["9"]
             if my_values := [
                 v
                 for v in self.apply_rules(marc_field, entity_mapping, index_or_legacy_id)

--- a/src/folio_migration_tools/marc_rules_transformation/rules_mapper_bibs.py
+++ b/src/folio_migration_tools/marc_rules_transformation/rules_mapper_bibs.py
@@ -165,7 +165,7 @@ class BibsRulesMapper(RulesMapperBase):
             Helper.log_data_issue(
                 legacy_ids,
                 "Multiple main entry fields in record. Record will fail Data Import. Creating Instance anyway.",
-                main_entry_fields
+                [str(x) for x in main_entry_fields]
             )
         if not main_entry_fields:
             main_entry_fields += marc_record.get_fields("700", "710", "711", "730")

--- a/src/folio_migration_tools/marc_rules_transformation/rules_mapper_bibs.py
+++ b/src/folio_migration_tools/marc_rules_transformation/rules_mapper_bibs.py
@@ -165,7 +165,7 @@ class BibsRulesMapper(RulesMapperBase):
             Helper.log_data_issue(
                 legacy_ids,
                 "Multiple main entry fields in record. Record will fail Data Import. Creating Instance anyway.",
-                [str(x) for x in main_entry_fields]
+                [str(field) for field in main_entry_fields]
             )
         if not main_entry_fields:
             main_entry_fields += marc_record.get_fields("700", "710", "711", "730")

--- a/src/folio_migration_tools/migration_tasks/holdings_csv_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/holdings_csv_transformer.py
@@ -209,7 +209,6 @@ class HoldingsCsvTransformer(MigrationTaskBase):
             self.holdings = {}
             self.total_records = 0
             self.holdings_id_map = self.load_id_map(self.folder_structure.holdings_id_map_path)
-            self.holdings_sources = self.get_holdings_sources()
             self.results_path = self.folder_structure.created_objects_path
             self.holdings_types = list(
                 self.folio_client.folio_get_all("/holdings-types", "holdingsTypes")
@@ -432,8 +431,6 @@ class HoldingsCsvTransformer(MigrationTaskBase):
         if not folio_rec.get("holdingsTypeId", ""):
             folio_rec["holdingsTypeId"] = self.fallback_holdings_type["id"]
 
-        folio_rec["sourceId"] = self.holdings_sources.get("FOLIO")
-
         holdings_from_row = []
         all_instance_ids = folio_rec.get("instanceId", [])
         if len(all_instance_ids) == 1:
@@ -520,20 +517,6 @@ class HoldingsCsvTransformer(MigrationTaskBase):
         self.holdings[holdings_key] = HoldingsHelper.merge_holding(
             self.holdings[holdings_key], new_holdings_record
         )
-
-    def get_holdings_sources(self):
-        res = {}
-        holdings_sources = list(
-            self.mapper.folio_client.folio_get_all("/holdings-sources", "holdingsRecordsSources")
-        )
-        logging.info("Fetched %s holdingsRecordsSources from tenant", len(holdings_sources))
-        res = {n["name"].upper(): n["id"] for n in holdings_sources}
-        if "FOLIO" not in res:
-            raise TransformationProcessError("", "No holdings source with name FOLIO in tenant")
-        if "MARC" not in res:
-            raise TransformationProcessError("", "No holdings source with name MARC in tenant")
-        logging.info(json.dumps(res, indent=4))
-        return res
 
 
 def explode_former_ids(folio_holding: dict):

--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -128,7 +128,8 @@ def mocked_file_mapper(mocked_folio_client):
         name="Test Task",
         migration_task_type="Test Task",
     )
-    return MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), task_config)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), task_config)
+    return mapper
 
 # flake8: noqa
 class MyTestableFileMapper(MappingFileMapperBase):
@@ -140,7 +141,7 @@ class MyTestableFileMapper(MappingFileMapperBase):
             schema,
             record_map,
             None,
-            FOLIONamespaces.holdings,
+            FOLIONamespaces.items,
             mock_conf,
         )
 
@@ -159,10 +160,10 @@ def test_validate_required_properties_sub_pro_missing_uri(mocked_folio_client: F
         "link_2": "",
         "id": "32",
     }
-    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.holdings)
+    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.items)
     assert len(folio_rec["electronicAccess"]) == 1
     assert folio_id == "32"
-    assert folio_rec["id"] == "bf204b6b-b600-5a06-9ec2-7f84f59e712e"
+    assert folio_rec["id"] == "132a9af6-7093-5df6-a8f0-ad0203fe3509"
 
 
 def test_validate_required_properties_sub_pro_missing_uri_and_more(
@@ -283,7 +284,7 @@ def test_validate_required_properties_sub_pro_missing_uri_and_more(
             },
         ]
     }
-    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     mocked_file_mapper.schema['properties'].update(schema['properties'])
     record = {
         "link_": "some_link",
@@ -296,8 +297,8 @@ def test_validate_required_properties_sub_pro_missing_uri_and_more(
         "third_0": "",
         "third_1": "",
     }
-    # tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.holdings)
+    # tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.items)
     assert len(folio_rec["electronicAccess"]) == 1
 
 
@@ -391,10 +392,43 @@ def test_validate_required_properties_item_notes(mocked_folio_client: FolioClien
         ]
     }
     record = {"note_1": "my note", "note_2": "", "id": "12"}
-    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.holdings)
+    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.items)
     ItemsTransformer.handle_notes(folio_rec)
     assert len(folio_rec["notes"]) == 1
+
+
+def test_instantiate_record_non_holdings(mocked_file_mapper: MappingFileMapperBase):
+    """
+    Test that we can instantiate a record that is not a holdings record
+    """
+    folio_record, _ = mocked_file_mapper.instantiate_record(
+        {
+            "id": "12345",
+            "barcode": "1234567890",
+        },
+        ["12345"],
+        FOLIONamespaces.items
+    )
+    assert "id" in folio_record
+    assert "sourceId" not in folio_record
+
+
+def test_instantiate_record_holdings(mocked_file_mapper: MappingFileMapperBase):
+    """
+    Test that we can instantiate a holdings record
+    """
+    mocked_file_mapper.holdings_sources = {"FOLIO": "source_id"}
+    folio_record, _ = mocked_file_mapper.instantiate_record(
+        {
+            "id": "12345",
+            "barcode": "1234567890",
+        },
+        ["12345"],
+        FOLIONamespaces.holdings
+    )
+    assert "sourceId" in folio_record
+    assert folio_record["sourceId"] == "source_id"
 
 
 def test_validate_required_properties_item_notes_defaults_in_simple_objects(
@@ -426,8 +460,8 @@ def test_validate_required_properties_item_notes_defaults_in_simple_objects(
         ]
     }
     record = {"title": "", "id": "aa_34"}
-    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.holdings)
+    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.items)
     ItemsTransformer.handle_notes(folio_rec)
     assert "title" in folio_rec
     assert folio_rec["title"] == "Fallback title"
@@ -523,8 +557,8 @@ def test_validate_required_properties_item_notes_unmapped(mocked_folio_client: F
         ]
     }
     record = {"note_1": "my note", "id": "34"}
-    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.holdings)
+    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.items)
     ItemsTransformer.handle_notes(folio_rec)
     assert len(folio_rec["notes"]) == 1
 
@@ -619,8 +653,8 @@ def test_validate_required_properties_item_notes_unmapped_2(mocked_folio_client:
         ]
     }
     record = {"note_1": "my note", "id": "35"}
-    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.holdings)
+    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.items)
     ItemsTransformer.handle_notes(folio_rec)
     assert len(folio_rec["notes"]) == 1
 
@@ -728,8 +762,8 @@ def test_validate_required_properties_obj(mocked_folio_client: FolioClient, mock
         "id": "36",
         "third_0": "",
     }
-    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.holdings)
+    mocked_file_mapper = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = mocked_file_mapper.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["electronicAccessObj"]["uri"] == "some_link"
 
 
@@ -884,8 +918,8 @@ def test_validate_required_properties_item_notes_split_on_delimiter_notes(
         ]
     }
     record = {"note_1": "my note<delimiter>my second note", "id": "37"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     ItemsTransformer.handle_notes(folio_rec)
     assert len(folio_rec["notes"]) == 2
     assert folio_rec["notes"][0]["note"] == "my note"
@@ -1240,11 +1274,11 @@ def test_multiple_repeated_split_on_delimiter_electronic_access(mocked_folio_cli
         "subtitle_": "object",
         "id": "38",
     }
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert len(folio_rec["electronicAccess"]) == 2
     assert folio_id == "38"
-    assert folio_rec["id"] == "3beee1b2-27ed-5597-9522-2c463eb449c6"
+    assert folio_rec["id"] == "64b9e49a-4d2d-5a56-a71c-d5ee57dfd2a2"
 
     assert folio_rec["electronicAccess"][0]["uri"] == "uri1"
     assert folio_rec["electronicAccess"][0]["linkText"] == "title1"
@@ -1309,8 +1343,8 @@ def test_validate_required_properties_item_notes_split_on_delimiter_plain_object
         ]
     }
     record = {"note_1": "my note<delimiter>my second note", "id": "39"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     ItemsTransformer.handle_notes(folio_rec)
     assert folio_rec["uber_prop"]["prop1"] == "my note<delimiter>my second note"
     assert folio_rec["uber_prop"]["prop2"] == "Some value"
@@ -1359,10 +1393,10 @@ def test_concatenate_fields_if_mapped_multiple_times(mocked_folio_client: FolioC
     }
     record = {"note_1": "my note", "note_2": "my second note", "id": "1493"}
     # Loop to make sure the right order occurs the first time.
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     for r in range(8000, 2000):
         record["id"] = str(r)
-        folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+        folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
         assert folio_rec["uber_prop"]["prop1"] == "my note my second note"
 
 
@@ -1411,10 +1445,10 @@ def test_concatenate_fields_if_mapped_multiple_times_and_data_is_in_random_order
     }
     record = {"note_2": "my second note", "id": "14", "note_1": "my note"}
     # Loop to make sure the right order occurs the first time.
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     for r in range(11000, 2000):
         record["id"] = str(r)
-        folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+        folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
         assert folio_rec["uber_prop"]["prop1"] == "my note my second note"
 
 
@@ -1460,8 +1494,8 @@ def test_do_not_split_string_prop(mocked_folio_client: FolioClient, mocked_file_
         "formerIds_1": "id2<delimiter>id3",
         "id": "15",
     }
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["formerId"] == "id2<delimiter>id3"
 
 
@@ -1507,8 +1541,8 @@ def test_split_former_ids(mocked_folio_client: FolioClient, mocked_file_mapper):
         "formerIds_2": "id2<delimiter>id3",
         "id": "16",
     }
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert len(folio_rec["formerIds"]) == 3
     assert "id1" in folio_rec["formerIds"]
     assert "id2" in folio_rec["formerIds"]
@@ -1604,8 +1638,8 @@ def test_validate_no_leakage_between_properties(mocked_folio_client: FolioClient
         ]
     }
     record = {"stmt_1": "stmt", "id": "17", "stmt_2": "suppl", "stmt_3": "idx"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert len(folio_rec["holdingsStatements"]) == 1
     assert folio_rec["holdingsStatements"][0]["statement"] == "stmt"
     assert len(folio_rec["holdingsStatementsForIndexes"]) == 1
@@ -1679,8 +1713,8 @@ def test_map_string_first_level(mocked_folio_client: FolioClient, mocked_file_ma
         ]
     }
     record = {"title_": "actual value", "id": "id"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["title"] == "actual value"
 
 
@@ -1716,8 +1750,8 @@ def test_map_string_array_first_level(mocked_folio_client: FolioClient, mocked_f
         ]
     }
     record = {"title_": "actual value", "id": "id"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_holdings_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["stringArray"][0] == "actual value"
 
 
@@ -1758,10 +1792,10 @@ def test_map_string_second_level(mocked_folio_client: FolioClient, mocked_file_m
     }
     record = {"id": "488", "note_1": "my note"}
     # Loop to make sure the right order occurs the first time.
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     for r in range(10000, 2000):
         record["id"] = str(r)
-        folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+        folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
         assert folio_rec["firstLevel"]["secondLevel"] == "my note"
 
 
@@ -1805,8 +1839,8 @@ def test_map_string_array_second_level(mocked_folio_client: FolioClient, mocked_
     record = {"id": "19", "note_1": "my note"}
     # Loop to make sure the right order occurs the first time.
 
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["firstLevel"]["stringArray"] == ["my note"]
 
 
@@ -1856,8 +1890,8 @@ def test_map_string_array_second_level_multiple_values(mocked_folio_client: Foli
     record = {"id": "20", "note_1": "my note", "note_2": "my note 2"}
     # Loop to make sure the right order occurs the first time.
 
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["firstLevel"]["stringArray"] == ["my note", "my note 2"]
 
 
@@ -1909,8 +1943,8 @@ def test_map_string_array_second_level_multiple_additional_split_values(
     record = {"id": "21", "note_1": "my note", "note_2": "my note 2<delimiter>my note 3"}
     # Loop to make sure the right order occurs the first time.
 
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["firstLevel"]["stringArray"] == ["my note", "my note 2", "my note 3"]
 
 
@@ -1960,8 +1994,8 @@ def test_map_string_array_second_level_split_values(mocked_folio_client: FolioCl
     record = {"id": "22", "note_2": "my note 2<delimiter>my note 3"}
     # Loop to make sure the right order occurs the first time.
 
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["firstLevel"]["stringArray"] == ["my note 2", "my note 3"]
 
 
@@ -2011,8 +2045,8 @@ def test_map_string_array_second_level_split_values_with_replace_values(
     }
     # Loop to make sure the right order occurs the first time.
 
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["firstLevel"]["stringArray"] == ["Cute Kitten", "Pretty Puppy"]
 
 
@@ -2061,8 +2095,8 @@ def test_map_array_of_objects_with_string_array(mocked_folio_client: FolioClient
     record = {"id": "23", "note_1": "my note", "note_2": "my note 2"}
     # Loop to make sure the right order occurs the first time.
 
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["firstLevel"][0]["secondLevel"] == ["my note", "my note 2"]
 
 
@@ -2111,8 +2145,8 @@ def test_map_array_of_objects_with_string_array_delimiter(mocked_folio_client: F
     record = {"id": "24", "note_1": "my note", "note_2": "my note 2<delimiter>my note 3"}
     # Loop to make sure the right order occurs the first time.
 
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["firstLevel"][0]["secondLevel"] == ["my note", "my note 2", "my note 3"]
 
 
@@ -2156,8 +2190,8 @@ def test_map_string_third_level(mocked_folio_client: FolioClient, mocked_file_ma
         ]
     }
     record = {"id": "25", "note_1": "my note"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert (
         folio_rec["firstLevel"]["secondLevel"]["thirdLevel"] == "my note"
     )  # No mapping on third level yet...
@@ -2224,8 +2258,8 @@ def test_map_string_and_array_of_strings_fourth_level(mocked_folio_client: Folio
         ]
     }
     record = {"id": "26", "note_1": "my note", "note_2": "my note 2", "note_3": "my note 3"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert folio_rec["firstLevel"]["secondLevel"]["thirdLevel"]["fourthLevel"] == "my note"
     assert folio_rec["firstLevel"]["secondLevel"]["thirdLevel"]["fourthLevelArr"] == [
         "my note 2",
@@ -2314,8 +2348,8 @@ def test_map_object_and_array_of_strings_fourth_level(mocked_folio_client: Folio
         ]
     }
     record = {"id": "27", "note_1": "my note", "note_2": "my note 2", "note_3": "my note 3"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, fake_item_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(record, record["id"], FOLIONamespaces.items)
     assert (
         folio_rec["firstLevel"]["secondLevel"]["thirdLevel"]["fourthLevel"]["fifthLevel1"]
         == "my note"
@@ -2437,7 +2471,7 @@ def test_map_enums(mocked_folio_client: FolioClient, mocked_file_mapper):
             {"folio_field": "status", "legacy_field": "status", "value": "", "description": ""},
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
     assert folio_rec["status"] == "Pending"
 
@@ -2554,7 +2588,7 @@ def test_map_enums_empty_required(mocked_folio_client, mocked_file_mapper):
         ]
     }
     with pytest.raises(TransformationRecordFailedError):
-        mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+        mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
         folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
 
 
@@ -2669,7 +2703,7 @@ def test_map_empty_not_required_enums(mocked_folio_client: FolioClient, mocked_f
             {"folio_field": "status", "legacy_field": "status", "value": "", "description": ""},
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
     assert "status" not in folio_rec
 
@@ -2706,7 +2740,7 @@ def test_map_enums_invalid_required(mocked_folio_client, mocked_file_mapper):
             {"folio_field": "status", "legacy_field": "status", "value": "", "description": ""},
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     with pytest.raises(TransformationRecordFailedError, match=r"Forbidden enum value found"):
         folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
 
@@ -2743,7 +2777,7 @@ def test_map_enums_invalid_not_required(mocked_folio_client, mocked_file_mapper)
             {"folio_field": "status", "legacy_field": "status", "value": "", "description": ""},
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     with pytest.raises(TransformationRecordFailedError, match=r"Forbidden enum value found"):
         folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
 
@@ -2825,7 +2859,7 @@ def test_map_enums_empty_not_required_deeper_level(mocked_folio_client, mocked_f
             },
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
     assert "deliveryMethod" not in folio_rec["interfaces"][0]
 
@@ -2892,7 +2926,7 @@ def test_map_enums_invalid_not_required_deeper_level(mocked_folio_client, mocked
             },
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     with pytest.raises(TransformationRecordFailedError, match=r"Forbidden enum value found"):
         folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
 
@@ -2940,7 +2974,7 @@ def test_map_booleans_regular_mapping(mocked_folio_client: FolioClient, mocked_f
         ]
     }
 
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_recs = []
 
     for record in records:
@@ -2999,7 +3033,7 @@ def test_map_booleans_with_replace_values(mocked_folio_client: FolioClient, mock
         ]
     }
 
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_recs = []
 
     for record in records:
@@ -3059,11 +3093,11 @@ def test_map_booeleans_set_schema_default(mocked_folio_client: FolioClient, mock
             },
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema_default_false, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema_default_false, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
     assert isinstance(folio_rec["trueOrFalse"], bool) and folio_rec["trueOrFalse"] is False
 
-    mapper = MappingFileMapperBase(mocked_folio_client, schema_default_true, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema_default_true, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
     assert isinstance(folio_rec["trueOrFalse"], bool) and folio_rec["trueOrFalse"] is True
 
@@ -3102,7 +3136,7 @@ def test_map_booleans_schema_default_false_and_mapped_to_true(mocked_folio_clien
             },
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
     assert folio_rec["trueOrFalse"] is True
 
@@ -3143,7 +3177,7 @@ def test_map_booleans_schema_default_false_and_value_set_to_true(mocked_folio_cl
             },
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
     assert folio_rec["trueOrFalse"] is True
 
@@ -3199,7 +3233,7 @@ def test_default_no_defaults_on_subprops(mocked_folio_client: FolioClient, mocke
             },
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
     assert "interfaces" not in folio_rec
 
@@ -3240,7 +3274,7 @@ def test_default_true(mocked_folio_client: FolioClient, mocked_file_mapper):
             },
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
     assert folio_rec["isVendor"] is True
 
@@ -3307,7 +3341,7 @@ def test_map_wrong_not_required_deeper_level_enums(mocked_folio_client: FolioCli
             },
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     with pytest.raises(TransformationRecordFailedError, match=r"Forbidden enum value found"):
         folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
 
@@ -3385,7 +3419,7 @@ def test_map_array_object_array_object_string(mocked_folio_client: FolioClient, 
         ]
     }
 
-    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = contact.do_map(record, record["id"], FOLIONamespaces.organizations)
 
     assert folio_rec["contacts"][0]["addresses"][0]["addressLine1"] == "My Street"
@@ -3480,7 +3514,7 @@ def test_do_not_overwrite_array_object_array_object_string_with_array_object_str
         ]
     }
 
-    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = contact.do_map(record, record["id"], FOLIONamespaces.organizations)
 
     assert folio_rec["contacts"][0]["firstName"] == "Jane"
@@ -3611,7 +3645,7 @@ def test_do_not_overwrite_array_object_array_object_string_with_array_object_str
         ]
     }
 
-    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = contact.do_map(record, record["id"], FOLIONamespaces.organizations)
 
     assert folio_rec["contacts"][0]["firstName"] == "Jane"
@@ -3686,7 +3720,7 @@ def test_map_array_object_array_string_on_edge(mocked_folio_client: FolioClient,
         ]
     }
 
-    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = contact.do_map(record, record["id"], FOLIONamespaces.organizations)
 
     assert folio_rec["contacts"][0]["streets"][0] == "My Street"
@@ -3744,7 +3778,7 @@ def test_map_array_object_array_string_on_edge_lowest(mocked_folio_client: Folio
         ]
     }
 
-    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = contact.do_map(record, record["id"], FOLIONamespaces.organizations)
 
     assert folio_rec["streets"][0] == "My Street"
@@ -3813,7 +3847,7 @@ def test_map_array_object_array_object_array_string(mocked_folio_client: FolioCl
         ]
     }
 
-    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    contact = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = contact.do_map(record, record["id"], FOLIONamespaces.organizations)
 
     assert folio_rec["contacts"][0]["addresses"][0]["categories"] == ["support", "sales"]
@@ -3856,9 +3890,9 @@ def test_get_prop_multiple_legacy_identifiers_only_one(mocked_folio_client: Foli
         },
     }
     legacy_record = {"firstLevel": "user_name_1", "id": "1 1"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, record_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(legacy_record, legacy_record["id"], FOLIONamespaces.holdings)
-    assert folio_rec["id"] == "addf3818-cd61-5edc-a243-cc205a45d46f"
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, record_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(legacy_record, legacy_record["id"], FOLIONamespaces.items)
+    assert folio_rec["id"] == "fbf2bbd4-a8bd-5571-9a60-8d8ad6ad22b0"
 
 
 def test_get_prop_multiple_legacy_identifiers(mocked_folio_client: FolioClient, mocked_file_mapper):
@@ -3897,9 +3931,9 @@ def test_get_prop_multiple_legacy_identifiers(mocked_folio_client: FolioClient, 
         },
     }
     legacy_record = {"firstLevel": "user_name_1", "id": "44", "id2": "1"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, record_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(legacy_record, legacy_record["id"], FOLIONamespaces.holdings)
-    assert folio_rec["id"] == "6eb3fe45-84ce-5487-9a36-720071673aca"
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, record_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(legacy_record, legacy_record["id"], FOLIONamespaces.items)
+    assert folio_rec["id"] == "57ef254c-c8c1-50e2-b331-55b9a2141391"
 
 
 def test_value_mapped_enum_properties(mocked_folio_client: FolioClient, mocked_file_mapper):
@@ -3932,8 +3966,8 @@ def test_value_mapped_enum_properties(mocked_folio_client: FolioClient, mocked_f
         },
     }
     legacy_record = {"id": "1"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, record_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(legacy_record, legacy_record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, record_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(legacy_record, legacy_record["id"], FOLIONamespaces.items)
     assert folio_rec["my_enum"] == "014/EAN"
 
 
@@ -3966,8 +4000,8 @@ def test_value_mapped_non_enum_properties(mocked_folio_client: FolioClient, mock
         },
     }
     legacy_record = {"id": "29"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, record_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(legacy_record, legacy_record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, record_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, folio_id = tfm.do_map(legacy_record, legacy_record["id"], FOLIONamespaces.items)
     assert folio_rec["my_enum"] == "014/EAN"
 
 
@@ -4000,8 +4034,8 @@ def test_value_not_mapped_mapped_non_enum_properties(mocked_folio_client: FolioC
         },
     }
     legacy_record = {"id": "30"}
-    tfm = MappingFileMapperBase(mocked_folio_client, schema, record_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
-    folio_rec, folio_id = tfm.do_map(legacy_record, legacy_record["id"], FOLIONamespaces.holdings)
+    tfm = MappingFileMapperBase(mocked_folio_client, schema, record_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    folio_rec, _ = tfm.do_map(legacy_record, legacy_record["id"], FOLIONamespaces.items)
     assert folio_rec["my_enum"] == "014/EAN"
 
 
@@ -4050,7 +4084,7 @@ def test_map_array_object_array_string(mocked_folio_client: FolioClient, mocked_
         ]
     }
 
-    interface = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    interface = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = interface.do_map(record, record["id"], FOLIONamespaces.organizations)
 
     assert folio_rec["interfaces"][0]["type"] == ["Admin"]
@@ -4215,7 +4249,7 @@ def test_get_prop(mocked_folio_client, mocked_file_mapper):
             },
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     res = mapper.get_prop(legacy_object, "title", "", "")
     assert res == "Alpha Omega"
 
@@ -4240,7 +4274,7 @@ def test_get_prop_one_value(mocked_folio_client, mocked_file_mapper):
             },
         ]
     }
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, the_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     res = mapper.get_prop(legacy_object, "title", "", "")
     assert res == "Alpha Beta"
 
@@ -4311,7 +4345,7 @@ def test_map_array_object_object_string(mocked_folio_client, mocked_file_mapper)
         ]
     }
 
-    interface = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    interface = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = interface.do_map(record, record["id"], FOLIONamespaces.organizations)
 
     assert folio_rec["interfaces"][0]["interfaceCredential"]["username"] == "MyUsername"
@@ -4363,7 +4397,7 @@ def test_map_array_object_subproperty_string(mocked_folio_client: FolioClient, m
         ]
     }
 
-    interface = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    interface = MappingFileMapperBase(mocked_folio_client, schema, org_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
     folio_rec, folio_id = interface.do_map(record, record["id"], FOLIONamespaces.organizations)
 
     assert folio_rec["interfaces"][0]["name"] == "FOLIO"
@@ -4552,7 +4586,7 @@ def test_add_default_from_schema(mocked_folio_client: FolioClient, mocked_file_m
             "cost_discount_type": "amount",
         },
     ]
-    mapper = MappingFileMapperBase(mocked_folio_client, schema, order_map, None, FOLIONamespaces.holdings, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
+    mapper = MappingFileMapperBase(mocked_folio_client, schema, order_map, None, FOLIONamespaces.items, mocked_classes.get_mocked_library_config(), mocked_file_mapper.task_configuration)
 
     folio_recs = []
 


### PR DESCRIPTION
## Purpose
<!-- Why are you making this change?  Provide the reviewer and future readers the cause that gave rise to this pull request. Include enough detail for a developer from another team to reconstruct the necessary context merely by reading this section.

You can link to an Issue by saying something like "Fixes #1" -->
* Fixes #925
* Fixes #926

## Changes Made in this PR
<!-- How does this change fulfill the purpose? It's best to talk high-level strategy and avoid restating the commit history. The goal is not only to explain what you did, but help other developers work with your solution in the future. -->
* Refactor CSV holdings transformer task to account for changes in required fields for Ramsons
* Fix a logging issue in BibTransformer
* Log data issue when invalid `authorityId` maps are present in FOLIO MARC-to-Instance map and allow process to proceed

## Code Review Specifics
<!-- Is this change trivial, or this project still in MVP just push along mode? Or is there an area you'd really like a thorough review? E.g:
- This just needs approval
- Read the code, make suggestions
- Fire it up and make sure it works
-
-->

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [ ] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## Warning Checklist
<!-- These items warn others about potential issues. Check any that apply. -->
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
<!-- Provide the steps necessary to verify the changes made to resolve the ticket acceptance criteria -->
* Build CSV holdings in Ramsons
* Run BibsTransformer task with invalid authorityId mappings in marc-to-instance mapping rules and bibs with multiple main entry (1xx) fields

## Open Questions
<!-- *OPTIONAL*
  - [ ] Use GitHub checklists to prompt discussion around questions you may have with your approach. When solved, check the box and explain the answer.
-->

## Learn Anything Cool?
<!-- *OPTIONAL* Crafting a solution sometimes requires a lot of research. Don't let all that hard work go to waste! Use this opportunity to share what you learned. Add links to blog posts, patterns, libraries, and other resources used to solve this problem. -->
