### PR TITLE
872 increase test coverage for items transformer

### DIFF
--- a/src/folio_migration_tools/migration_tasks/items_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/items_transformer.py
@@ -127,7 +127,8 @@ class ItemsTransformer(MigrationTaskBase):
                 title="Statistical code map file name",
                 description=(
                     "Path to the file containing the mapping of statistical codes. "
-                    "The file should be in TSV format with legacy_stat_code and folio_code columns."
+                    "The file should be in TSV format with legacy_stat_code "
+                    "and folio_code columns."
                 ),
             ),
         ] = ""
@@ -355,7 +356,7 @@ class ItemsTransformer(MigrationTaskBase):
                     )
 
                     self.mapper.perform_additional_mappings(legacy_id, folio_rec, file_def)
-                    self.handle_circiulation_notes(folio_rec, self.folio_client.current_user)
+                    self.handle_circulation_notes(folio_rec, self.folio_client.current_user)
                     self.handle_notes(folio_rec)
                     if folio_rec["holdingsRecordId"] in self.boundwith_relationship_map:
                         for idx_, instance_id in enumerate(
@@ -373,7 +374,7 @@ class ItemsTransformer(MigrationTaskBase):
                     if idx == 0:
                         logging.info("First FOLIO record:")
                         logging.info(json.dumps(folio_rec, indent=4))
-                    # TODO: turn this into a asynchrounous task
+                    # TODO: turn this into a asynchronous task
                     Helper.write_to_file(results_file, folio_rec)
                     self.mapper.migration_report.add_general_statistics(
                         i18n.t("Number of records written to disk")
@@ -388,8 +389,8 @@ class ItemsTransformer(MigrationTaskBase):
                     logging.fatal(attribute_error)
                     logging.info("Quitting...")
                     sys.exit(1)
-                except Exception as excepion:
-                    self.mapper.handle_generic_exception(idx, excepion)
+                except Exception as exception:
+                    self.mapper.handle_generic_exception(idx, exception)
                 self.mapper.migration_report.add(
                     "GeneralStatistics",
                     i18n.t("Number of Legacy items in %{container}", container=file_def),
@@ -425,14 +426,14 @@ class ItemsTransformer(MigrationTaskBase):
                 del folio_object["notes"]
 
     @staticmethod
-    def handle_circiulation_notes(folio_rec, current_user_uuid):
+    def handle_circulation_notes(folio_rec, current_user_uuid):
         if not folio_rec.get("circulationNotes", []):
             return
         filtered_notes = []
         for circ_note in folio_rec.get("circulationNotes", []):
             if circ_note.get("noteType", "") not in ["Check in", "Check out"]:
                 raise TransformationProcessError(
-                    "", "Circulation Note types are not mapped correclty"
+                    "", "Circulation Note types are not mapped correctly"
                 )
             if circ_note.get("note", ""):
                 circ_note["id"] = str(uuid.uuid4())
@@ -455,11 +456,17 @@ class ItemsTransformer(MigrationTaskBase):
                         json.loads(x) for x in boundwith_relationship_file
                     )
             logging.info(
-                    "Rows in Bound with relationship map: %s", len(self.boundwith_relationship_map)
+                "Rows in Bound with relationship map: %s",
+                len(self.boundwith_relationship_map)
                 )
         except FileNotFoundError:
             raise TransformationProcessError(
-                    "", "Boundwith relationship file specified, but relationships file from holdings transformation not found. ", self.folder_structure.boundwith_relationships_map_path
+                "",
+                (
+                    "Boundwith relationship file specified, but relationships file "
+                    "from holdings transformation not found."
+                ),
+                self.folder_structure.boundwith_relationships_map_path
             )
 
     def wrap_up(self):

--- a/src/folio_migration_tools/migration_tasks/items_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/items_transformer.py
@@ -462,11 +462,16 @@ class ItemsTransformer(MigrationTaskBase):
         except FileNotFoundError:
             raise TransformationProcessError(
                 "",
-                (
-                    "Boundwith relationship file specified, but relationships file "
-                    "from holdings transformation not found."
-                ),
+                "Boundwith relationship file specified, but relationships file "
+                "from holdings transformation not found.",
                 self.folder_structure.boundwith_relationships_map_path
+            )
+        except ValueError:
+            raise TransformationProcessError(
+                "",
+                "Boundwith relationship file specified, but relationships file "
+                "from holdings transformation is not a valid line JSON.",
+                self.folder_structure.boundwith_relationships_map_path,
             )
 
     def wrap_up(self):

--- a/tests/test_items_transformer.py
+++ b/tests/test_items_transformer.py
@@ -77,3 +77,18 @@ def test_load_boundwith_relationships_invalid_json(items_transformer):
     with patch("builtins.open", mock_open(read_data=mock_data)):
         with pytest.raises(json.JSONDecodeError):
             ItemsTransformer.load_boundwith_relationships(items_transformer)
+
+
+def test_load_boundwith_relationships_empty_file(items_transformer):
+    mock_data = ''
+    with patch("builtins.open", mock_open(read_data=mock_data)):
+        ItemsTransformer.load_boundwith_relationships(items_transformer)
+        assert len(items_transformer.boundwith_relationship_map) == 0
+
+
+def test_load_boundwith_relationships_map_not_a_list(items_transformer):
+    mock_data = '{"key1": ["value1"]}'
+    with patch("builtins.open", mock_open(read_data=mock_data)):
+        with pytest.raises(ValueError):
+            ItemsTransformer.load_boundwith_relationships(items_transformer)
+

--- a/tests/test_items_transformer.py
+++ b/tests/test_items_transformer.py
@@ -11,34 +11,35 @@ import json
 from unittest.mock import mock_open, patch
 
 
-def test_handle_circiulation_notes_wrong_type():
+def test_handle_circulation_notes_wrong_type():
     folio_rec = {
         "circulationNotes": [{"id": "someId", "noteType": "Check inn", "note": "some note"}]
     }
     with pytest.raises(TransformationProcessError):
-        ItemsTransformer.handle_circiulation_notes(folio_rec, str(uuid.uuid4()))
+        ItemsTransformer.handle_circulation_notes(folio_rec, str(uuid.uuid4()))
 
 
-def test_handle_circiulation_notes_no_note():
+def test_handle_circulation_notes_no_note():
     folio_rec = {"circulationNotes": [{"id": "someId", "noteType": "Check in", "note": ""}]}
-    ItemsTransformer.handle_circiulation_notes(folio_rec, str(uuid.uuid4()))
+    ItemsTransformer.handle_circulation_notes(folio_rec, str(uuid.uuid4()))
     assert "circulationNotes" not in folio_rec
 
 
-def test_handle_circiulation_notes_happy_path():
+def test_handle_circulation_notes_happy_path():
     folio_rec = {
         "circulationNotes": [
             {"id": "someId", "noteType": "Check in", "note": "some_note"},
             {"id": "someId", "noteType": "Check in", "note": ""},
         ]
     }
-    ItemsTransformer.handle_circiulation_notes(folio_rec, str(uuid.uuid4()))
+    ItemsTransformer.handle_circulation_notes(folio_rec, str(uuid.uuid4()))
     assert folio_rec["circulationNotes"][0]["note"] == "some_note"
     assert len(folio_rec["circulationNotes"]) == 1
 
 
 def test_get_object_type():
     assert ItemsTransformer.get_object_type() == FOLIONamespaces.items
+
 
 @pytest.fixture
 def items_transformer():
@@ -62,10 +63,13 @@ def test_load_boundwith_relationships_happy_path(items_transformer):
 
 
 def test_load_boundwith_relationships_file_not_found(items_transformer):
-    with patch("builtins.open", side_effect=FileNotFoundError):
-        with pytest.raises(TransformationProcessError) as excinfo:
+    with (patch("builtins.open", side_effect=FileNotFoundError)):
+        with pytest.raises(TransformationProcessError) as exc_info:
             ItemsTransformer.load_boundwith_relationships(items_transformer)
-        assert "Boundwith relationship file specified, but relationships file from holdings transformation not found." in str(excinfo.value)
+        assert (
+                "Boundwith relationship file specified, but relationships file "
+                "from holdings transformation not found."
+               ) in str(exc_info.value)
 
 
 def test_load_boundwith_relationships_invalid_json(items_transformer):

--- a/tests/test_items_transformer.py
+++ b/tests/test_items_transformer.py
@@ -63,7 +63,7 @@ def test_load_boundwith_relationships_happy_path(items_transformer):
 
 
 def test_load_boundwith_relationships_file_not_found(items_transformer):
-    with (patch("builtins.open", side_effect=FileNotFoundError)):
+    with patch("builtins.open", side_effect=FileNotFoundError):
         with pytest.raises(TransformationProcessError) as exc_info:
             ItemsTransformer.load_boundwith_relationships(items_transformer)
         assert (
@@ -75,8 +75,12 @@ def test_load_boundwith_relationships_file_not_found(items_transformer):
 def test_load_boundwith_relationships_invalid_json(items_transformer):
     mock_data = '["key1", ["value1"]\n["key2", ["value2"]]'
     with patch("builtins.open", mock_open(read_data=mock_data)):
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(TransformationProcessError) as exc_info:
             ItemsTransformer.load_boundwith_relationships(items_transformer)
+            assert (
+                   "Boundwith relationship file specified, but relationships file "
+                   "from holdings transformation is not a valid line JSON."
+                   ) in str(exc_info.value)
 
 
 def test_load_boundwith_relationships_empty_file(items_transformer):
@@ -89,6 +93,9 @@ def test_load_boundwith_relationships_empty_file(items_transformer):
 def test_load_boundwith_relationships_map_not_a_list(items_transformer):
     mock_data = '{"key1": ["value1"]}'
     with patch("builtins.open", mock_open(read_data=mock_data)):
-        with pytest.raises(ValueError):
+        with pytest.raises(TransformationProcessError) as exc_info:
             ItemsTransformer.load_boundwith_relationships(items_transformer)
-
+        assert (
+                "Boundwith relationship file specified, but relationships file "
+                "from holdings transformation is not a valid line JSON."
+               ) in str(exc_info.value)


### PR DESCRIPTION
## Purpose
Partially fixes [#872](https://github.com/FOLIO-FSE/folio_migration_tools/issues/872)

## Changes Made in this PR
Added tests for load_boundwith_relationships, some refactor

## Code Review Specifics
- Read the code, make suggestions

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [x] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## How to Verify
```bash
poetry run pytest -v ./tests/test_items_transformer.py
```
