### PR TITLE
873 Increase test coverage for user_transformer

### DIFF
--- a/tests/test_user_transformer.py
+++ b/tests/test_user_transformer.py
@@ -1,6 +1,10 @@
 import logging
 
-from folio_migration_tools.migration_tasks.user_transformer import UserTransformer
+from folio_migration_tools.migration_tasks.user_transformer import (
+    UserTransformer,
+    remove_empty_addresses,
+    find_primary_addresses,
+)
 from folio_uuid.folio_namespaces import FOLIONamespaces
 
 LOGGER = logging.getLogger(__name__)
@@ -121,3 +125,80 @@ def test_clean_user_no_valid_address_data():
     }
     UserTransformer.clean_user(folio_user, "id")
     assert "addresses" not in folio_user["personal"]
+
+
+def test_remove_empty_addresses_removes_empty():
+    folio_user = {
+        "personal": {
+            "addresses": [
+                {"id": "1", "addressTypeId": "type1", "primaryAddress": True},
+                {"id": "2", "addressLine1": "123 Main St", "primaryAddress": False},
+                {"id": "3", "addressLine2": "Apt 4", "addressTypeId": "type2"},
+                {"id": "4", "primaryAddress": False, "addressTypeId": "type3"},
+            ]
+        }
+    }
+    result = remove_empty_addresses(folio_user)
+    # Only address 2 and 3 have fields other than id, addressTypeId, primaryAddress
+    assert len(result) == 2
+    assert any(a["id"] == "2" for a in result)
+    assert any(a["id"] == "3" for a in result)
+
+
+def test_remove_empty_addresses_no_addresses():
+    folio_user = {"personal": {}}
+    result = remove_empty_addresses(folio_user)
+    assert result == []
+
+
+def test_remove_empty_addresses_all_valid():
+    folio_user = {
+        "personal": {
+            "addresses": [
+                {"id": "1", "addressLine1": "A", "primaryAddress": True},
+                {"id": "2", "addressLine2": "B", "primaryAddress": False},
+            ]
+        }
+    }
+    result = remove_empty_addresses(folio_user)
+    assert len(result) == 2
+
+
+def test_find_primary_addresses_sets_missing_to_false():
+    addresses = [
+        {"addressLine1": "A"},
+        {"addressLine1": "B", "primaryAddress": True},
+        {"addressLine1": "C", "primaryAddress": "True"},
+        {"addressLine1": "D", "primaryAddress": "False"},
+    ]
+    primary = find_primary_addresses(addresses)
+    assert len(primary) == 2
+    assert addresses[0]["primaryAddress"] is False
+    assert addresses[3]["primaryAddress"] is False
+
+
+def test_find_primary_addresses_handles_bool_and_str():
+    addresses = [
+        {"addressLine1": "A", "primaryAddress": True},
+        {"addressLine1": "B", "primaryAddress": "true"},
+        {"addressLine1": "C", "primaryAddress": False},
+        {"addressLine1": "D", "primaryAddress": "False"},
+    ]
+    primary = find_primary_addresses(addresses)
+    assert len(primary) == 2
+    for addr in addresses:
+        if addr["addressLine1"] in ["A", "B"]:
+            assert addr["primaryAddress"] is True or addr["primaryAddress"] == "true"
+        else:
+            assert addr["primaryAddress"] is False
+
+
+def test_find_primary_addresses_all_missing():
+    addresses = [
+        {"addressLine1": "A"},
+        {"addressLine1": "B"},
+    ]
+    primary = find_primary_addresses(addresses)
+    assert len(primary) == 0
+    for addr in addresses:
+        assert addr["primaryAddress"] is False


### PR DESCRIPTION
## Purpose
Fixes [#873](https://github.com/FOLIO-FSE/folio_migration_tools/issues/873)

## Changes Made in this PR
Added unit tests for:
* remove_empty_addresses
* find_primary_addresses

## Code Review Specifics
- This just needs approval
- Read the code, make suggestions

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [x] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## How to Verify
```bash
poetry run pytest -v ./tests/test_user_transformer.py
```