### PR TITLE
870 Increase test coverage for holdings_marc_transformer

### DIFF
--- a/src/folio_migration_tools/migration_tasks/holdings_marc_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/holdings_marc_transformer.py
@@ -1,5 +1,3 @@
-'''Main "script."'''
-
 import csv
 import json
 import logging
@@ -19,7 +17,10 @@ from folio_migration_tools.library_configuration import (
 from folio_migration_tools.marc_rules_transformation.rules_mapper_holdings import (
     RulesMapperHoldings,
 )
-from folio_migration_tools.migration_tasks.migration_task_base import MarcTaskConfigurationBase, MigrationTaskBase
+from folio_migration_tools.migration_tasks.migration_task_base import (
+    MarcTaskConfigurationBase,
+    MigrationTaskBase
+)
 
 
 class HoldingsMarcTransformer(MigrationTaskBase):
@@ -37,14 +38,18 @@ class HoldingsMarcTransformer(MigrationTaskBase):
             str,
             Field(
                 title="Migration task type",
-                description=("The type of migration task you want to perform"),
+                description=(
+                    "The type of migration task you want to perform"
+                ),
             ),
         ]
         files: Annotated[
             List[FileDefinition],
             Field(
                 title="Source files",
-                description=("List of MARC21 files with holdings records"),
+                description=(
+                    "List of MARC21 files with holdings records"
+                ),
             ),
         ]
         hrid_handling: Annotated[
@@ -125,8 +130,8 @@ class HoldingsMarcTransformer(MigrationTaskBase):
         default_call_number_type_name: Annotated[
             str,
             Field(
-                title="Default callnumber type name",
-                description="The name of the callnumber type that will be used as fallback",
+                title="Default call_number type name",
+                description="The name of the call_number type that will be used as fallback",
             ),
         ]
         fallback_holdings_type_id: Annotated[
@@ -140,7 +145,10 @@ class HoldingsMarcTransformer(MigrationTaskBase):
             str,
             Field(
                 title="Supplemental MFHD mapping rules file",
-                description="The name of the file in the mapping_files directory containing supplemental MFHD mapping rules",
+                description=(
+                    "The name of the file in the mapping_files directory "
+                    "containing supplemental MFHD mapping rules"
+                ),
             ),
         ] = ""
         include_mrk_statements: Annotated[
@@ -148,8 +156,10 @@ class HoldingsMarcTransformer(MigrationTaskBase):
             Field(
                 title="Include MARC statements (MRK-format) as staff-only Holdings notes",
                 description=(
-                    "If set to true, the MARC statements will be included in the output as MARC Maker format fields. "
-                    "If set to false (default), the MARC statements will not be included in the output."
+                    "If set to true, the MARC statements "
+                    "will be included in the output as MARC Maker format fields. "
+                    "If set to false (default), the MARC statements "
+                    "will not be included in the output."
                 ),
             ),
         ] = False
@@ -188,7 +198,8 @@ class HoldingsMarcTransformer(MigrationTaskBase):
                 title="Include MARC Record (as MARC21 decoded string) as note",
                 description=(
                     "If set to true, the MARC record will be included in the output as a "
-                    "decoded binary MARC21 record. If set to false (default), the MARC record will not be "
+                    "decoded binary MARC21 record. If set to false (default), "
+                    "the MARC record will not be "
                     "included in the output."
                 ),
             ),
@@ -215,6 +226,7 @@ class HoldingsMarcTransformer(MigrationTaskBase):
         use_logging: bool = True,
     ):
         csv.register_dialect("tsv", delimiter="\t")
+        self.task_configuration = task_config
         super().__init__(library_config, task_config, folio_client, use_logging)
         if self.task_configuration.statistical_codes_map_file_name:
             statcode_mapping = self.load_ref_data_mapping_file(

--- a/src/folio_migration_tools/migration_tasks/holdings_marc_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/holdings_marc_transformer.py
@@ -226,7 +226,6 @@ class HoldingsMarcTransformer(MigrationTaskBase):
         use_logging: bool = True,
     ):
         csv.register_dialect("tsv", delimiter="\t")
-        self.task_configuration = task_config
         super().__init__(library_config, task_config, folio_client, use_logging)
         if self.task_configuration.statistical_codes_map_file_name:
             statcode_mapping = self.load_ref_data_mapping_file(

--- a/src/folio_migration_tools/task_configuration.py
+++ b/src/folio_migration_tools/task_configuration.py
@@ -25,7 +25,9 @@ class AbstractTaskConfiguration(BaseModel):
         str,
         Field(
             title="Migration task type",
-            description=("The type of migration task you want to perform."),
+            description=(
+                "The type of migration task you want to perform."
+            ),
         ),
     ]
     ecs_tenant_id: Annotated[

--- a/tests/test_holdings_marc_transformer.py
+++ b/tests/test_holdings_marc_transformer.py
@@ -1,9 +1,77 @@
+from unittest.mock import Mock, mock_open, patch
+import pytest
+from pathlib import Path
+from folio_migration_tools.test_infrastructure import mocked_classes
+
 from folio_uuid.folio_namespaces import FOLIONamespaces
 
 from folio_migration_tools.migration_tasks.holdings_marc_transformer import (
     HoldingsMarcTransformer,
 )
+from folio_migration_tools.custom_exceptions import TransformationProcessError
 
 
 def test_get_object_type():
     assert HoldingsMarcTransformer.get_object_type() == FOLIONamespaces.holdings
+
+
+@pytest.fixture
+def holdings_marc_transformer():
+    mock_config = Mock(spec=HoldingsMarcTransformer.TaskConfiguration)
+    mock_config.ecs_tenant_id = ""
+    mock_config.name = "test"
+    mock_config.boundwith_relationships_map_path = "some_path"
+    marc_transformer = Mock(spec=HoldingsMarcTransformer)
+    marc_transformer.folder_structure = mocked_classes.get_mocked_folder_structure()
+    marc_transformer.folder_structure.boundwith_relationships_map_path = "some_path"
+    marc_transformer.task_configuration = mock_config
+    return marc_transformer
+
+
+def test_add_supplemental_mfhd_mappings_happy_path():
+    mock_data = '{"001": "value1", "002": "value2"}'
+    transformer = Mock(spec=HoldingsMarcTransformer)
+    transformer.task_configuration = Mock()
+    transformer.task_configuration.supplemental_mfhd_mapping_rules_file = "dummy.json"
+    transformer.folder_structure = mocked_classes.get_mocked_folder_structure()
+    transformer.folder_structure.mapping_files_folder = Path(".")
+    transformer.mapper = Mock()
+    with patch("builtins.open", mock_open(read_data=mock_data)):
+        HoldingsMarcTransformer.add_supplemental_mfhd_mappings(transformer)
+        transformer.mapper.integrate_supplemental_mfhd_mappings.assert_called_once_with(
+            {"001": "value1", "002": "value2"}
+        )
+
+
+def test_add_supplemental_mfhd_mappings_empty_file():
+    transformer = Mock(spec=HoldingsMarcTransformer)
+    transformer.task_configuration = Mock()
+    transformer.task_configuration.supplemental_mfhd_mapping_rules_file = ""
+    transformer.mapper = Mock()
+    HoldingsMarcTransformer.add_supplemental_mfhd_mappings(transformer)
+    transformer.mapper.integrate_supplemental_mfhd_mappings.assert_called_once_with({})
+
+
+def test_add_supplemental_mfhd_mappings_invalid_json():
+    mock_data = '{"001": "value1", "002": "value2"'
+    transformer = Mock(spec=HoldingsMarcTransformer)
+    transformer.task_configuration = Mock()
+    transformer.task_configuration.supplemental_mfhd_mapping_rules_file = "dummy.json"
+    transformer.folder_structure = mocked_classes.get_mocked_folder_structure()
+    transformer.folder_structure.mapping_files_folder = Path(".")
+    transformer.mapper = Mock()
+    with patch("builtins.open", mock_open(read_data=mock_data)):
+        with pytest.raises(Exception):
+            HoldingsMarcTransformer.add_supplemental_mfhd_mappings(transformer)
+
+
+def test_add_supplemental_mfhd_mappings_file_not_found():
+    transformer = Mock(spec=HoldingsMarcTransformer)
+    transformer.task_configuration = Mock()
+    transformer.task_configuration.supplemental_mfhd_mapping_rules_file = "dummy.json"
+    transformer.folder_structure = mocked_classes.get_mocked_folder_structure()
+    transformer.folder_structure.mapping_files_folder = Path(".")
+    transformer.mapper = Mock()
+    with patch("builtins.open", side_effect=FileNotFoundError):
+        with pytest.raises(TransformationProcessError):
+            HoldingsMarcTransformer.add_supplemental_mfhd_mappings(transformer)


### PR DESCRIPTION
## Purpose
Fixes [#870](https://github.com/FOLIO-FSE/folio_migration_tools/issues/870)

## Changes Made in this PR
- refactored typos, long lines and some variables defenition
- add some tests

## Code Review Specifics
- Read the code, make suggestions

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [x] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## How to Verify
```bash
poetry run pytest -v ./tests/test_holdings_marc_transformer.py
```
