### PR TITLE
888 increase test coverage for user_mapper

### DIFF
--- a/src/folio_migration_tools/mapping_file_transformation/user_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/user_mapper.py
@@ -59,8 +59,8 @@ class UserMapper(MappingFileMapperBase):
                 True,
             )
             self.notes_mapper.migration_report = self.migration_report
-            self.setup_departments_mapping(departments_mapping)
-            self.setup_groups_mapping(groups_map)
+            self.departments_mapping = self.setup_departments_mapping(departments_mapping)
+            self.groups_mapping = self.setup_groups_mapping(groups_map)
 
             for m in self.record_map["data"]:
                 if m["folio_field"].startswith("customFields"):
@@ -120,7 +120,8 @@ class UserMapper(MappingFileMapperBase):
 
         return clean_folio_object
 
-    def get_users(self, source_file, file_format: str):
+    @staticmethod
+    def get_users(source_file, file_format: str):
         csv.register_dialect("tsv", delimiter="\t")
         if file_format == "tsv":
             reader = csv.DictReader(source_file, dialect="tsv")
@@ -184,27 +185,21 @@ class UserMapper(MappingFileMapperBase):
             return ""
 
     def setup_groups_mapping(self, groups_map):
-        if groups_map:
-            self.groups_mapping = RefDataMapping(
-                self.folio_client,
-                "/groups",
-                "usergroups",
-                groups_map,
-                "group",
-                "UserGroupMapping",
-            )
-        else:
-            self.groups_mapping = None
+        return RefDataMapping(
+            self.folio_client,
+            "/groups",
+            "usergroups",
+            groups_map,
+            "group",
+            "UserGroupMapping",
+        ) if groups_map else None
 
     def setup_departments_mapping(self, departments_mapping):
-        if departments_mapping:
-            self.departments_mapping = RefDataMapping(
-                self.folio_client,
-                "/departments",
-                "departments",
-                departments_mapping,
-                "name",
-                "DepartmentsMapping",
-            )
-        else:
-            self.departments_mapping = None
+        return RefDataMapping(
+            self.folio_client,
+            "/departments",
+            "departments",
+            departments_mapping,
+            "name",
+            "DepartmentsMapping",
+        ) if departments_mapping else None


### PR DESCRIPTION
## Purpose
Fixes [#888](https://github.com/FOLIO-FSE/folio_migration_tools/issues/888)

## Changes Made in this PR
- refactored for better code reading
- transfer method get_users to static
- 

## Code Review Specifics
- Read the code, make suggestions

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [x] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `python -m folio_migration_tools -h`
- [ ] Documentation updated

## How to Verify
```bash
python -m pytest -v ./tests/test_user_mapper.py
```