### PR TITLE
Custom legacy id field for bibs doesn't work if the field is a control field (< 010)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folio_migration_tools"
-version = "1.12.8"
+version = "1.12.9"
 description =  "A tool allowing you to migrate data from legacy ILS:s (Library systems) into FOLIO LSP"
 authors = [
 	{name = "Theodor Tolstoy", email = "github.teddes@tolstoy.se"},

--- a/src/folio_migration_tools/marc_rules_transformation/rules_mapper_bibs.py
+++ b/src/folio_migration_tools/marc_rules_transformation/rules_mapper_bibs.py
@@ -716,7 +716,7 @@ def get_custom_bib_id(marc_record: Record, field_string: str):
             if len(field_keys) == 2:
                 return [marc_record[field_keys[0]][field_keys[1]]]
             else:
-                return [marc_record[field_keys[0]]]
+                return [marc_record[field_keys[0]].value()]
         except Exception as e:
             raise TransformationRecordFailedError(
                 "unknown identifier",

--- a/tests/test_rules_mapper_bibs_no_folio.py
+++ b/tests/test_rules_mapper_bibs_no_folio.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.propagate = True
 
 from folio_migration_tools.custom_exceptions import TransformationFieldMappingError
+from folio_migration_tools.custom_exceptions import TransformationRecordFailedError
 from folio_migration_tools.library_configuration import FileDefinition
 from folio_migration_tools.library_configuration import FolioRelease
 from folio_migration_tools.library_configuration import HridHandling
@@ -22,6 +23,9 @@ from folio_migration_tools.library_configuration import IlsFlavour
 from folio_migration_tools.library_configuration import LibraryConfiguration
 from folio_migration_tools.marc_rules_transformation.rules_mapper_bibs import (
     BibsRulesMapper,
+)
+from folio_migration_tools.marc_rules_transformation.rules_mapper_bibs import (
+    get_custom_bib_id,
 )
 from folio_migration_tools.migration_report import MigrationReport
 from folio_migration_tools.migration_tasks.bibs_transformer import BibsTransformer
@@ -556,3 +560,58 @@ def test_required_properties_classification_missing_a(mapper: BibsRulesMapper, c
         mapping_082 = mapper.mappings["082"][0]
         folio_record: dict = {}
         mapper.handle_entity_mapping(bad_082, mapping_082, folio_record, ["reqprop_entity_1"])
+
+
+def test_get_custom_bib_id_field_value_no_subfield():
+    record = pymarc.Record()
+    record.add_field(pymarc.Field(tag="001", data="legacy_id_99"))
+    res = get_custom_bib_id(record, "001")
+    assert res == ["legacy_id_99"]
+
+
+def test_get_custom_bib_id_with_subfield():
+    record = pymarc.Record()
+    record.add_field(
+        pymarc.Field(
+            tag="035",
+            indicators=[" ", " "],
+            subfields=[Subfield(code="a", value="legacy_id_99")],
+        )
+    )
+    res = get_custom_bib_id(record, "035$a")
+    assert res == ["legacy_id_99"]
+
+
+def test_get_custom_bib_id_field_missing_raises():
+    record = pymarc.Record()
+    with pytest.raises(TransformationRecordFailedError) as exception_info:
+        get_custom_bib_id(record, "035$a")
+    assert "035$a is missing from record but is required in all records" in str(
+        exception_info.value
+    )
+
+
+def test_get_custom_bib_id_subfield_missing_raises():
+    record = pymarc.Record()
+    record.add_field(
+        pymarc.Field(
+            tag="035",
+            indicators=[" ", " "],
+            subfields=[Subfield(code="b", value="not the right subfield")],
+        )
+    )
+    with pytest.raises(TransformationRecordFailedError) as exception_info:
+        get_custom_bib_id(record, "035$a")
+    assert "035$a is missing from record but is required in all records" in str(
+        exception_info.value
+    )
+
+
+def test_get_custom_bib_id_empty_field_string_raises():
+    # An empty field_string still yields a truthy split result (['']), so this
+    # takes the "field missing from record" path rather than the "no
+    # customBibIdField configured" path.
+    record = pymarc.Record()
+    with pytest.raises(TransformationRecordFailedError) as exception_info:
+        get_custom_bib_id(record, "")
+    assert "is missing from record but is required in all records" in str(exception_info.value)


### PR DESCRIPTION
## Purpose
<!-- Why are you making this change?  Provide the reviewer and future readers the cause that gave rise to this pull request. Include enough detail for a developer from another team to reconstruct the necessary context merely by reading this section.

You can link to an Issue by saying something like "Fixes #1" -->
Fixes #1040

## Changes Made in this PR
<!-- How does this change fulfill the purpose? It's best to talk high-level strategy and avoid restating the commit history. The goal is not only to explain what you did, but help other developers work with your solution in the future. -->
- When not subfield is specified for the `customBibIdField`, we now call value on the `Field` object indicated before returning the list of legacy id values.
- Added new tests

## Code Review Specifics
<!-- Is this change trivial, or this project still in MVP just push along mode? Or is there an area you'd really like a thorough review? E.g:
- This just needs approval
- Read the code, make suggestions
- Fire it up and make sure it works
-
-->

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [ ] Ran `nox -rs safety`.
- [x] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## Warning Checklist
<!-- These items warn others about potential issues. Check any that apply. -->
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
<!-- Provide the steps necessary to verify the changes made to resolve the ticket acceptance criteria -->

## Open Questions
<!-- *OPTIONAL*
  - [ ] Use GitHub checklists to prompt discussion around questions you may have with your approach. When solved, check the box and explain the answer.
-->

## Learn Anything Cool?
<!-- *OPTIONAL* Crafting a solution sometimes requires a lot of research. Don't let all that hard work go to waste! Use this opportunity to share what you learned. Add links to blog posts, patterns, libraries, and other resources used to solve this problem. -->
