### PR TITLE
replaceValues cannot assign an empty string to a value

### DIFF
--- a/docs/source/mapping_file_based_mapping.md
+++ b/docs/source/mapping_file_based_mapping.md
@@ -297,6 +297,26 @@ This rule allows you to map codes to strings. Given the following mapping:
 If the STATUS field contains *0*, then the resulting value in the note title will be *Graduate*.
 If no match is made, the original string will be returned. So if STATUS is *1*, then the note title will be *1*.
 
+You can also map a code to an empty string, which is useful for clearing out unwanted filler values
+in the legacy data (like *N/A* or *0*) without having to preprocess the source data first:
+
+```
+{
+    "folio_field": "notes[0].title",
+    "legacy_field": "STATUS",
+    "value": "",
+    "description": "",
+    "fallback_legacy_field": "",
+    "rules": {
+        "replaceValues": {
+            "N/A": ""
+        }
+    }
+},
+```
+
+If STATUS is *N/A*, the resulting value will be an empty string, not the original *N/A*.
+
 ## Validation of Hardcoded Note Type Values
 
 When mapping item or holdings note types (`itemNoteTypeId` or `holdingsNoteTypeId` fields), any hardcoded values specified in the `value` or `fallback_value` properties are validated at mapper initialization. This ensures that mapping files are correct before data transformation begins.

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -36,6 +36,10 @@ logger = logging.getLogger(__name__)
 
 empty_vals = ["Not mapped", None, ""]
 
+# Sentinel used to distinguish "no replaceValues rule matched" from a rule that
+# intentionally maps a value to a falsy replacement (e.g. "").
+_REPLACE_VALUE_MISSING = object()
+
 
 class MappingFileMapperBase(MapperBase):
     def __init__(
@@ -492,21 +496,29 @@ class MappingFileMapperBase(MapperBase):
             value = re.sub(pattern, replacement, value)
 
         if mapping_file_entry.get("rules", {}).get("replaceValues", {}):
+            replace_map = mapping_file_entry["rules"]["replaceValues"]
             if multi_field_delimiter and multi_field_delimiter in value:
-                replaced_split_values = [
-                    mapping_file_entry["rules"]["replaceValues"].get(sv, "")
-                    for sv in value.split(multi_field_delimiter)
-                ]
+                # Fall back to the original sub-value (not "") when a sub-value has no
+                # matching rule, so unmapped sub-values are left untouched.
+                replaced_split_values = []
+                for sv in value.split(multi_field_delimiter):
+                    rv = replace_map.get(sv, _REPLACE_VALUE_MISSING)
+                    replaced_split_values.append(sv if rv is _REPLACE_VALUE_MISSING else rv)
                 replaced_val = multi_field_delimiter.join(replaced_split_values)
             else:
-                replaced_val = mapping_file_entry["rules"]["replaceValues"].get(value, "")
+                # Use a sentinel default instead of "" so a rule that intentionally maps
+                # a value to "" isn't mistaken for "no rule matched" and discarded.
+                replaced_val = replace_map.get(value, _REPLACE_VALUE_MISSING)
+                replaced_val = value if replaced_val is _REPLACE_VALUE_MISSING else replaced_val
 
-            if replaced_val or isinstance(replaced_val, bool):
+            # Compare to the original value, not truthiness, so replacements to/from
+            # falsy values (e.g. "") are applied and reported correctly.
+            if replaced_val != value:
                 migration_report.add(
                     "FieldMappingDetails",
                     f"Replaced {value} in {source_field} with {replaced_val}",
                 )
-                value = replaced_val
+            value = replaced_val
 
         if mapping_file_entry.get("rules", {}).get("regexGetFirstMatchOrEmpty", ""):
             my_pattern = (
@@ -812,6 +824,10 @@ class MappingFileMapperBase(MapperBase):
             mapped_prop = self.get_prop(
                 legacy_object, property_name, index_or_id, schema_property.get("default", "")
             )
+            # Implementation note: a property resolved to "" (e.g. via a replaceValues rule
+            # that intentionally clears a value) is not written to the output record here.
+            # get_prop() can't distinguish "a rule cleared it" from "nothing was mapped",
+            # so we drop it in both cases rather than risk writing spurious empty strings.
             if mapped_prop or isinstance(mapped_prop, bool):
                 self.validate_enums(
                     mapped_prop,

--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -3584,6 +3584,71 @@ def test_map_booleans_with_replace_values(mocked_folio_client: FolioClient, mock
     assert isinstance(folio_recs[1]["trueOrFalse"], bool) and folio_recs[1]["trueOrFalse"] is False
 
 
+def test_map_string_with_replace_values_to_empty_string(
+    mocked_folio_client: FolioClient, mocked_file_mapper
+):
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "description": "A generic record",
+        "type": "object",
+        "properties": {
+            "id": {
+                "description": "The unique UUID for this organization",
+                "$ref": "../../common/schemas/uuid.json",
+                "type": "string",
+            },
+            "note": {
+                "id": "note",
+                "description": "A note field that may be cleared via replaceValues",
+                "type": "string",
+            },
+        },
+    }
+    records = [
+        {"id": "test_map_empty_string_with_replace_values1", "note": "N/A"},
+        {"id": "test_map_empty_string_with_replace_values2", "note": "unmapped value"},
+    ]
+
+    the_map = {
+        "data": [
+            {
+                "folio_field": "legacyIdentifier",
+                "legacy_field": "id",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "note",
+                "legacy_field": "note",
+                "value": "",
+                "description": "",
+                "rules": {"replaceValues": {"N/A": ""}},
+            },
+        ]
+    }
+
+    mapper = MappingFileMapperBase(
+        mocked_folio_client,
+        schema,
+        the_map,
+        None,
+        FOLIONamespaces.items,
+        mocked_classes.get_mocked_library_config(),
+        mocked_file_mapper.task_configuration,
+    )
+    folio_recs = []
+
+    for record in records:
+        folio_rec, folio_id = mapper.do_map(record, record["id"], FOLIONamespaces.organizations)
+        folio_recs.append(folio_rec)
+
+    # map_basic_props intentionally drops properties resolved to "" (see comment there),
+    # so the replaced empty string never reaches the output record. What matters here is
+    # that it does not fall back to the original, unreplaced legacy value ("N/A") either.
+    assert "note" not in folio_recs[0]
+    assert folio_recs[1].get("note") == "unmapped value"
+
+
 def test_map_booeleans_set_schema_default(mocked_folio_client: FolioClient, mocked_file_mapper):
     schema_default_false = {
         "properties": {
@@ -4893,6 +4958,51 @@ def test_get_legacy_value_replace_value():
         legacy_object, mapping_file_entry, MigrationReport(), ""
     )
     assert res == "Graduate"
+
+
+def test_get_legacy_value_replace_value_with_empty_string():
+    legacy_object = {"title": "N/A"}
+    mapping_file_entry = {
+        "folio_field": "title",
+        "legacy_field": "title",
+        "value": "",
+        "description": "",
+        "rules": {"replaceValues": {"N/A": ""}},
+    }
+    res = MappingFileMapperBase.get_legacy_value(
+        legacy_object, mapping_file_entry, MigrationReport(), ""
+    )
+    assert res == ""
+
+
+def test_get_legacy_value_replace_value_unmapped_falls_back_to_original():
+    legacy_object = {"title": "unmapped value"}
+    mapping_file_entry = {
+        "folio_field": "title",
+        "legacy_field": "title",
+        "value": "",
+        "description": "",
+        "rules": {"replaceValues": {"N/A": ""}},
+    }
+    res = MappingFileMapperBase.get_legacy_value(
+        legacy_object, mapping_file_entry, MigrationReport(), ""
+    )
+    assert res == "unmapped value"
+
+
+def test_get_legacy_value_replace_value_multi_value_empty_string_and_unmapped():
+    legacy_object = {"title": "N/A<delimiter>unmapped value"}
+    mapping_file_entry = {
+        "folio_field": "title",
+        "legacy_field": "title",
+        "value": "",
+        "description": "",
+        "rules": {"replaceValues": {"N/A": ""}},
+    }
+    res = MappingFileMapperBase.get_legacy_value(
+        legacy_object, mapping_file_entry, MigrationReport(), "", "<delimiter>"
+    )
+    assert res == "<delimiter>unmapped value"
 
 
 def test_get_legacy_value_regex():


### PR DESCRIPTION
## Purpose
<!-- Why are you making this change?  Provide the reviewer and future readers the cause that gave rise to this pull request. Include enough detail for a developer from another team to reconstruct the necessary context merely by reading this section.

You can link to an Issue by saying something like "Fixes #1" -->
Fixes #1038

## Changes Made in this PR
<!-- How does this change fulfill the purpose? It's best to talk high-level strategy and avoid restating the commit history. The goal is not only to explain what you did, but help other developers work with your solution in the future. -->
- Refactored `replaceValues` implementation to use a sentinel value when a value is not replaced, rather than an empty string.
- Added tests

## Code Review Specifics
<!-- Is this change trivial, or this project still in MVP just push along mode? Or is there an area you'd really like a thorough review? E.g:
- This just needs approval
- Read the code, make suggestions
- Fire it up and make sure it works
-
-->

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [ ] Ran `nox -rs safety`.
- [x] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [x] Documentation updated

## Warning Checklist
<!-- These items warn others about potential issues. Check any that apply. -->
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
<!-- Provide the steps necessary to verify the changes made to resolve the ticket acceptance criteria -->

## Open Questions
<!-- *OPTIONAL*
  - [ ] Use GitHub checklists to prompt discussion around questions you may have with your approach. When solved, check the box and explain the answer.
-->

## Learn Anything Cool?
<!-- *OPTIONAL* Crafting a solution sometimes requires a lot of research. Don't let all that hard work go to waste! Use this opportunity to share what you learned. Add links to blog posts, patterns, libraries, and other resources used to solve this problem. -->
- Using sentinel values like this is new to me, but useful when you need to do boolean logic around the truthiness of values that would otherwise be considered false.