### PR TITLE
Fix patronGroup/departments mapping to fall back to hybrid wildcard rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,3 @@ Translate all new strings, which begin with `TRANSLATE`, then commit.
 
 # Running the scripts
 For information on syntax, what files are needed and produced by the toolkit, refer to the documentation and example files in the [template repository](https://github.com/FOLIO-FSE/migration_repo_template). We are building out the docs section in this repository as well:[Documentation](https://folio-migration-tools.readthedocs.io/en/latest/)
-¨

--- a/src/folio_migration_tools/mapper_base.py
+++ b/src/folio_migration_tools/mapper_base.py
@@ -130,6 +130,9 @@ class MapperBase:
             # Gets the first line in the map satisfying all legacy mapping values.
             # Case insensitive, strips away whitespace
             right_mapping = ref_data_mapping.get_ref_data_mapping(legacy_object)
+            if not right_mapping:
+                # Not all fields matched. Could it be a hybrid wildcard map?
+                right_mapping = ref_data_mapping.get_hybrid_mapping(legacy_object)
 
             if not right_mapping:
                 raise StopIteration()

--- a/tests/test_user_mapper.py
+++ b/tests/test_user_mapper.py
@@ -1118,6 +1118,78 @@ def test_ref_data_group_mapping(mocked_folio_client):
     assert folio_user["patronGroup"] == "FOLIO group name"
 
 
+def test_ref_data_group_mapping_multi_column_hybrid_wildcard(mocked_folio_client):
+    user_map = {
+        "data": [
+            {
+                "folio_field": "username",
+                "legacy_field": "user_name",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "externalSystemId",
+                "legacy_field": "ext_id",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "legacyIdentifier",
+                "legacy_field": "id",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "personal.lastName",
+                "legacy_field": "",
+                "value": "Last name",
+                "description": "",
+            },
+            {
+                "folio_field": "patronGroup",
+                "legacy_field": "patron_group",
+                "value": "",
+                "description": "",
+            },
+        ]
+    }
+    legacy_user_record = {
+        "patron_group": "GROUP_A",
+        "stat_code_copy": "some_code_not_in_map",
+        "ext_id": "externalid_1",
+        "user_name": "user_name_1",
+        "id": "1",
+    }
+    groups_map = [
+        {
+            "patron_group": "GROUP_B",
+            "stat_code_copy": "CODE_1",
+            "folio_group": "FOLIO group name",
+        },
+        {
+            "patron_group": "GROUP_A",
+            "stat_code_copy": "*",
+            "folio_group": "FOLIO fallback group name",
+        },
+        {"patron_group": "*", "stat_code_copy": "*", "folio_group": "FOLIO group name"},
+    ]
+    mock_library_conf = mocked_classes.get_mocked_library_config()
+    mock_task_config = Mock(spec=UserTransformer.TaskConfiguration)
+    mock_task_config.remove_id_and_request_preferences = False
+    mock_task_config.remove_request_preferences = False
+    mock_task_config.remove_username = False
+    mock_library_conf.multi_field_delimiter = "<delimiter>"
+    mock_folio = mocked_folio_client
+    user_mapper = UserMapper(
+        mock_folio, mock_task_config, mock_library_conf, user_map, None, groups_map
+    )
+    folio_user, index_or_id = user_mapper.do_map(legacy_user_record, "001", FOLIONamespaces.users)
+    folio_user = user_mapper.perform_additional_mapping(
+        legacy_user_record, folio_user, index_or_id
+    )
+    assert folio_user["patronGroup"] == "FOLIO fallback group name"
+
+
 def test_ref_data_departments_mapping(mocked_folio_client):
     user_map = {
         "data": [


### PR DESCRIPTION
## Purpose
<!-- Why are you making this change?  Provide the reviewer and future readers the cause that gave rise to this pull request. Include enough detail for a developer from another team to reconstruct the necessary context merely by reading this section.

You can link to an Issue by saying something like "Fixes #1" -->
Fixes #1043

## Changes Made in this PR
<!-- How does this change fulfill the purpose? It's best to talk high-level strategy and avoid restating the commit history. The goal is not only to explain what you did, but help other developers work with your solution in the future. -->

## Code Review Specifics
<!-- Is this change trivial, or this project still in MVP just push along mode? Or is there an area you'd really like a thorough review? E.g:
- This just needs approval
- Read the code, make suggestions
- Fire it up and make sure it works
-
-->

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [ ] Ran `nox -rs safety`.
- [x] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## Warning Checklist
<!-- These items warn others about potential issues. Check any that apply. -->
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
<!-- Provide the steps necessary to verify the changes made to resolve the ticket acceptance criteria -->

## Open Questions
<!-- *OPTIONAL*
  - [ ] Use GitHub checklists to prompt discussion around questions you may have with your approach. When solved, check the box and explain the answer.
-->

## Learn Anything Cool?
<!-- *OPTIONAL* Crafting a solution sometimes requires a lot of research. Don't let all that hard work go to waste! Use this opportunity to share what you learned. Add links to blog posts, patterns, libraries, and other resources used to solve this problem. -->
